### PR TITLE
docs: Add benchmark readiness roadmap by SP

### DIFF
--- a/docs/plans/11-benchmarking.md
+++ b/docs/plans/11-benchmarking.md
@@ -76,6 +76,26 @@ Create a comprehensive benchmark suite that measures cqlsh-rs performance across
 | `cqlshrc_load_file` | `nonexistent_file`, `minimal_file`, `full_file` | File I/O + parsing combined |
 | `end_to_end_startup` | `minimal`, `full` | Complete startup path (parse CLI + load config + merge) |
 
+##### Benchmark Readiness by SP — Add Benchmarks Incrementally
+
+> **Key insight:** Benchmarks should NOT wait until Phase 5. Add each benchmark
+> group immediately after its corresponding SP is implemented. The CI
+> infrastructure (bench.yml, GitHub Pages dashboard) is already in place.
+
+| SP | Component | Benchmarks Unlocked | Benchmark File |
+|----|-----------|---------------------|----------------|
+| **SP1** ✅ | CLI & Config | `cli_parse_args`, `cqlshrc_parse`, `config_merge`, `end_to_end_startup` | `startup.rs` ✅ |
+| **SP4** | Statement Parser | `parse_statement`, `parse_multiline` | `parser.rs` |
+| **SP2** | Driver & Connection | Macro-benchmarks: connect + query roundtrip (hyperfine) | `macro/` |
+| **SP6 + SP9** | Output Formatting + CQL Types | `format_table_{10,100,1000}`, `format_json_100`, `format_csv_100`, `format_each_type` | `format.rs` |
+| **SP5** | Tab Completion | `complete_keyword`, `complete_table`, `complete_column` | `completion.rs` |
+| **SP8** | COPY TO/FROM | COPY throughput macro-benchmarks (hyperfine), COPY memory benchmarks | `macro/` |
+
+> **Action:** After completing each SP above, immediately implement its
+> corresponding benchmarks before moving to the next SP. This ensures
+> performance regressions are caught early and baselines are established
+> while the code is fresh.
+
 ##### Planned — Future phases
 
 | Benchmark | File | What it Measures |


### PR DESCRIPTION
## Summary
Added a new section to the benchmarking plan that outlines when benchmarks should be implemented relative to each Scope Phase (SP), emphasizing incremental benchmark addition rather than deferring all benchmarks to Phase 5.

## Key Changes
- **New "Benchmark Readiness by SP" section** that maps each SP to its corresponding benchmark group and target file
- **Clarified benchmark implementation strategy**: benchmarks should be added immediately after each SP is completed, not deferred until Phase 5
- **Documented benchmark unlocks** for each phase:
  - SP1: CLI & Config benchmarks (`startup.rs`) ✅ already implemented
  - SP4: Statement Parser benchmarks (`parser.rs`)
  - SP2: Driver & Connection macro-benchmarks
  - SP6 + SP9: Output Formatting benchmarks (`format.rs`)
  - SP5: Tab Completion benchmarks (`completion.rs`)
  - SP8: COPY TO/FROM benchmarks
- **Added actionable guidance** to catch performance regressions early and establish baselines while code is fresh

## Implementation Details
- References existing CI infrastructure (bench.yml, GitHub Pages dashboard) already in place
- Provides clear mapping between SPs and benchmark files for implementation tracking
- Emphasizes the importance of establishing performance baselines incrementally rather than as an afterthought

https://claude.ai/code/session_01Wk8QKRPWk1ucCjkPVjkJJt