### PR TITLE
Ensure gh-pages branch exists before storing benchmark results

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -69,6 +69,17 @@ jobs:
           path: output.txt
           retention-days: 90
 
+      - name: Ensure gh-pages branch exists
+        run: |
+          if ! git ls-remote --exit-code origin gh-pages >/dev/null 2>&1; then
+            echo "Creating gh-pages branch..."
+            git checkout --orphan gh-pages
+            git reset --hard
+            git commit --allow-empty -m "chore: initialize gh-pages branch"
+            git push origin gh-pages
+            git checkout -
+          fi
+
       - name: Store results & track history
         uses: benchmark-action/github-action-benchmark@v1
         with:


### PR DESCRIPTION
## Summary
Added a pre-flight check in the benchmark workflow to ensure the `gh-pages` branch exists before attempting to store benchmark results. This prevents workflow failures when the branch hasn't been initialized yet.

## Key Changes
- Added a new workflow step that checks if the `gh-pages` branch exists on the remote
- If the branch doesn't exist, the step automatically creates it as an orphan branch with an initial empty commit
- The step runs before the benchmark results are stored, ensuring the target branch is always available

## Implementation Details
The check uses `git ls-remote` to verify branch existence without requiring a local clone, making it efficient. If the branch is missing, it:
1. Creates an orphan branch (no history)
2. Resets the working directory
3. Creates an initial empty commit with a descriptive message
4. Pushes the new branch to origin
5. Returns to the previous branch to continue the workflow

This ensures the workflow can run successfully even on fresh repositories without manual setup.

https://claude.ai/code/session_018QA1PLXBF1vN9cnbDHp28Q