### PR TITLE
fix(driver): add debug logging for value conversion and remove redundant error context

### DIFF
--- a/src/driver/scylla_driver.rs
+++ b/src/driver/scylla_driver.rs
@@ -135,9 +135,20 @@ impl ScyllaDriver {
             let values: Vec<CqlValue> = row
                 .columns
                 .into_iter()
-                .map(|opt_val| match opt_val {
-                    Some(v) => Self::convert_scylla_value(v),
-                    None => CqlValue::Null,
+                .enumerate()
+                .map(|(col_idx, opt_val)| match opt_val {
+                    Some(v) => {
+                        tracing::debug!(
+                            column = col_idx,
+                            variant = ?std::mem::discriminant(&v),
+                            "converting ScyllaCqlValue: {v:?}"
+                        );
+                        Self::convert_scylla_value(v)
+                    }
+                    None => {
+                        tracing::debug!(column = col_idx, "column value is None (null)");
+                        CqlValue::Null
+                    }
                 })
                 .collect();
             cql_rows.push(CqlRow { values });
@@ -236,7 +247,10 @@ impl ScyllaDriver {
                 CqlValue::Varint(big_int)
             }
             // CqlValue is non-exhaustive; handle future variants gracefully
-            _ => CqlValue::Text(format!("{value:?}")),
+            _ => {
+                tracing::warn!("unhandled ScyllaCqlValue variant: {value:?}");
+                CqlValue::Text(format!("{value:?}"))
+            }
         }
     }
 
@@ -350,11 +364,7 @@ impl CqlDriver for ScyllaDriver {
     async fn execute_unpaged(&self, query: &str) -> Result<CqlResult> {
         let stmt = self.build_query(query);
 
-        let result = self
-            .session
-            .query_unpaged(stmt, ())
-            .await
-            .context("executing CQL query")?;
+        let result = self.session.query_unpaged(stmt, ()).await?;
 
         self.store_trace_id(&result);
         Self::convert_query_result(result)


### PR DESCRIPTION
## Summary
- Add `tracing::debug!` in row conversion loop to log each `ScyllaCqlValue` variant before conversion — enables diagnosing empty column values (e.g. empty `cluster_name` from Bug 1 in PR #17 review)
- Add `tracing::warn!` when the catch-all branch handles an unrecognized `ScyllaCqlValue` variant
- Remove redundant `.context("executing CQL query")` from `execute_unpaged` — the driver error from ScyllaDB is already descriptive, and this was contributing to the "wall of text" error messages (Bug 2 in PR #17 review)

## Context
Found during manual testing of PR #17. The REPL-side error display fix was already merged in `bf94e05`. This PR covers the remaining driver-side fixes.

To diagnose Bug 1 (empty `cluster_name`), run:
```bash
RUST_LOG=debug ./target/release/cqlsh-rs -e "SELECT cluster_name FROM system.local"
```

## Test plan
- [x] `cargo test --lib` — 130 tests pass
- [x] `cargo clippy` — no warnings
- [ ] Manual: verify `RUST_LOG=debug` shows ScyllaCqlValue variants in output
- [ ] Manual: verify error messages no longer include "executing CQL query" prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)