### PR TITLE
Add GitHub CLI auto-installation hook for Claude sessions

### DIFF
--- a/.claude/hooks/install-gh-cli.sh
+++ b/.claude/hooks/install-gh-cli.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# SessionStart hook: install gh CLI if not present
+set -euo pipefail
+
+if command -v gh &>/dev/null; then
+  exit 0
+fi
+
+GH_VERSION="2.65.0"
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64)  ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+esac
+
+TARBALL="gh_${GH_VERSION}_linux_${ARCH}.tar.gz"
+URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${TARBALL}"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+curl -fsSL "$URL" -o "$TMPDIR/$TARBALL"
+tar -xzf "$TMPDIR/$TARBALL" -C "$TMPDIR"
+cp "$TMPDIR/gh_${GH_VERSION}_linux_${ARCH}/bin/gh" /usr/local/bin/gh
+chmod +x /usr/local/bin/gh

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/install-gh-cli.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds automatic installation of the GitHub CLI (`gh`) tool when Claude sessions start, ensuring the tool is available for use without manual setup.

## Key Changes
- **New hook script** (`.claude/hooks/install-gh-cli.sh`): Bash script that checks if `gh` CLI is installed and automatically downloads and installs version 2.65.0 if missing
  - Supports both x86_64 and ARM64 architectures
  - Uses temporary directory for safe cleanup
  - Installs binary to `/usr/local/bin/gh`
  
- **New configuration file** (`.claude/settings.json`): Defines Claude hooks configuration
  - Registers the install script as a `SessionStart` hook
  - Ensures the installation script runs automatically when sessions begin

## Implementation Details
- The installation script uses `curl` to download the official GitHub CLI release tarball
- Architecture detection handles both `x86_64` (mapped to `amd64`) and `aarch64` (mapped to `arm64`)
- Early exit if `gh` is already installed to avoid redundant downloads
- Proper error handling with `set -euo pipefail` and cleanup via trap

https://claude.ai/code/session_01EmWYLFqv1L5jVYs9hu8RtU