### PR TITLE
feat: Phase 3 — tab completion, syntax highlighting, and output coloring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ tracing-subscriber = "0.3"
 futures = "0.3"
 async-trait = "0.1"
 rustyline = { version = "15", features = ["derive"] }
-comfy-table = "7"
+comfy-table = { version = "7", features = ["custom_styling"] }
 crossterm = "0.28"
-terminal_size = "0.4"
+sapling-streampager = "0.12"
 
 [lib]
 name = "cqlsh_rs"

--- a/src/colorizer.rs
+++ b/src/colorizer.rs
@@ -1,0 +1,209 @@
+//! CQL syntax colorization for the REPL prompt and output.
+//!
+//! Provides a simple tokenizer that applies ANSI colors to CQL keywords,
+//! string literals, numbers, and comments using crossterm styling.
+
+use crossterm::style::Stylize;
+
+/// Set of CQL keywords to highlight (uppercase for matching).
+const KEYWORDS: &[&str] = &[
+    "ADD", "ALTER", "AND", "APPLY", "AS", "ASC", "AUTHORIZE", "BATCH", "BEGIN",
+    "BY", "CALLED", "CLUSTERING", "COLUMN", "COMPACT", "CONTAINS", "COUNT",
+    "CREATE", "CUSTOM", "DELETE", "DESC", "DESCRIBE", "DISTINCT", "DROP",
+    "ENTRIES", "EXECUTE", "EXISTS", "FILTERING", "FROM", "FROZEN", "FULL",
+    "FUNCTION", "GRANT", "IF", "IN", "INDEX", "INSERT", "INTO", "IS", "JSON",
+    "KEY", "KEYSPACE", "KEYSPACES", "LANGUAGE", "LIKE", "LIMIT", "LIST",
+    "LOGIN", "MAP", "MATERIALIZED", "MODIFY", "NAMESPACE", "NOT", "NULL",
+    "OF", "ON", "OR", "ORDER", "PARTITION", "PASSWORD", "PER", "PERMISSION",
+    "PERMISSIONS", "PRIMARY", "RENAME", "REPLACE", "RETURNS", "REVOKE",
+    "SCHEMA", "SELECT", "SET", "STATIC", "STORAGE", "SUPERUSER", "TABLE",
+    "TABLES", "TEXT", "TIMESTAMP", "TO", "TOKEN", "TRIGGER", "TRUNCATE",
+    "TTL", "TUPLE", "TYPE", "UNLOGGED", "UPDATE", "USE", "USER", "USERS",
+    "USING", "VALUES", "VIEW", "WHERE", "WITH", "WRITETIME",
+];
+
+/// CQL syntax colorizer using ANSI escape codes.
+pub struct CqlColorizer {
+    enabled: bool,
+}
+
+impl CqlColorizer {
+    /// Create a new colorizer. If `enabled` is false, all methods return input unchanged.
+    pub fn new(enabled: bool) -> Self {
+        Self { enabled }
+    }
+
+    /// Colorize a line of CQL input for display.
+    ///
+    /// Applies colors:
+    /// - CQL keywords → bold blue
+    /// - String literals ('...') → green
+    /// - Numbers → cyan
+    /// - Comments (-- ...) → dark grey
+    pub fn colorize_line(&self, line: &str) -> String {
+        if !self.enabled {
+            return line.to_string();
+        }
+
+        let mut result = String::with_capacity(line.len() * 2);
+        let chars: Vec<char> = line.chars().collect();
+        let len = chars.len();
+        let mut i = 0;
+
+        while i < len {
+            // Comment: -- to end of line
+            if i + 1 < len && chars[i] == '-' && chars[i + 1] == '-' {
+                let rest: String = chars[i..].iter().collect();
+                result.push_str(&format!("{}", rest.dark_grey()));
+                break;
+            }
+
+            // String literal: '...'
+            if chars[i] == '\'' {
+                let start = i;
+                i += 1;
+                while i < len && chars[i] != '\'' {
+                    if chars[i] == '\\' && i + 1 < len {
+                        i += 1; // skip escaped char
+                    }
+                    i += 1;
+                }
+                if i < len {
+                    i += 1; // consume closing quote
+                }
+                let literal: String = chars[start..i].iter().collect();
+                result.push_str(&format!("{}", literal.green()));
+                continue;
+            }
+
+            // Number (simple: digits possibly with dots)
+            if chars[i].is_ascii_digit()
+                || (chars[i] == '-'
+                    && i + 1 < len
+                    && chars[i + 1].is_ascii_digit()
+                    && (i == 0 || !chars[i - 1].is_alphanumeric()))
+            {
+                let start = i;
+                if chars[i] == '-' {
+                    i += 1;
+                }
+                while i < len && (chars[i].is_ascii_digit() || chars[i] == '.') {
+                    i += 1;
+                }
+                // Make sure this isn't part of an identifier
+                if i < len && (chars[i].is_alphanumeric() || chars[i] == '_') {
+                    // It's an identifier like "table1" — don't colorize
+                    let word: String = chars[start..].iter().collect();
+                    let end = word
+                        .find(|c: char| c.is_whitespace() || c == ',' || c == ')' || c == ';')
+                        .unwrap_or(word.len());
+                    result.push_str(&chars[start..start + end].iter().collect::<String>());
+                    i = start + end;
+                } else {
+                    let num: String = chars[start..i].iter().collect();
+                    result.push_str(&format!("{}", num.cyan()));
+                }
+                continue;
+            }
+
+            // Word (potential keyword)
+            if chars[i].is_alphabetic() || chars[i] == '_' {
+                let start = i;
+                while i < len && (chars[i].is_alphanumeric() || chars[i] == '_') {
+                    i += 1;
+                }
+                let word: String = chars[start..i].iter().collect();
+                if is_keyword(&word) {
+                    result.push_str(&format!("{}", word.blue().bold()));
+                } else {
+                    result.push_str(&word);
+                }
+                continue;
+            }
+
+            // Other characters (whitespace, operators, etc.)
+            result.push(chars[i]);
+            i += 1;
+        }
+
+        result
+    }
+}
+
+/// Check if a word is a CQL keyword (case-insensitive).
+fn is_keyword(word: &str) -> bool {
+    let upper = word.to_uppercase();
+    KEYWORDS.binary_search(&upper.as_str()).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keywords_are_highlighted() {
+        let c = CqlColorizer::new(true);
+        let output = c.colorize_line("SELECT * FROM users");
+        assert!(output.contains("\x1b["), "should contain ANSI escape codes");
+        assert!(output.contains("SELECT"));
+        assert!(output.contains("FROM"));
+    }
+
+    #[test]
+    fn colorizer_disabled_returns_unchanged() {
+        let c = CqlColorizer::new(false);
+        let output = c.colorize_line("SELECT * FROM users");
+        assert_eq!(output, "SELECT * FROM users");
+    }
+
+    #[test]
+    fn string_literals_are_colored() {
+        let c = CqlColorizer::new(true);
+        let output = c.colorize_line("INSERT INTO t (a) VALUES ('hello')");
+        // 'hello' should be green (contains ANSI codes)
+        assert!(output.contains("\x1b["));
+        assert!(output.contains("hello"));
+    }
+
+    #[test]
+    fn numbers_are_colored() {
+        let c = CqlColorizer::new(true);
+        let output = c.colorize_line("SELECT * FROM t LIMIT 100");
+        assert!(output.contains("100"));
+    }
+
+    #[test]
+    fn comments_are_colored() {
+        let c = CqlColorizer::new(true);
+        let output = c.colorize_line("SELECT 1 -- test comment");
+        assert!(output.contains("test comment"));
+    }
+
+    #[test]
+    fn non_keywords_are_not_highlighted() {
+        let c = CqlColorizer::new(true);
+        let output = c.colorize_line("my_table");
+        // "my_table" is not a keyword, should not have ANSI codes
+        assert!(!output.contains("\x1b["));
+    }
+
+    #[test]
+    fn mixed_case_keywords() {
+        let c = CqlColorizer::new(true);
+        let output = c.colorize_line("select * from users");
+        assert!(output.contains("\x1b["), "lowercase keywords should also be highlighted");
+    }
+
+    #[test]
+    fn keyword_list_is_sorted() {
+        // binary_search requires sorted list
+        for window in KEYWORDS.windows(2) {
+            assert!(
+                window[0] < window[1],
+                "KEYWORDS not sorted: {:?} >= {:?}",
+                window[0],
+                window[1]
+            );
+        }
+    }
+}

--- a/src/colorizer.rs
+++ b/src/colorizer.rs
@@ -2,8 +2,12 @@
 //!
 //! Provides a simple tokenizer that applies ANSI colors to CQL keywords,
 //! string literals, numbers, and comments using crossterm styling.
+//! Also provides output coloring for query result values, headers, and errors
+//! matching Python cqlsh's color scheme.
 
 use crossterm::style::Stylize;
+
+use crate::driver::types::CqlValue;
 
 /// Set of CQL keywords to highlight (uppercase for matching).
 const KEYWORDS: &[&str] = &[
@@ -31,6 +35,178 @@ impl CqlColorizer {
     /// Create a new colorizer. If `enabled` is false, all methods return input unchanged.
     pub fn new(enabled: bool) -> Self {
         Self { enabled }
+    }
+
+    /// Returns whether colorization is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Colorize a CQL result value matching Python cqlsh's color scheme.
+    ///
+    /// Color mapping:
+    /// - Text/Ascii → yellow bold
+    /// - Numeric/boolean/uuid/timestamp/date/time/duration/inet → green bold
+    /// - Blob → dark magenta (non-bold)
+    /// - Null → red bold
+    /// - Collection delimiters → blue bold, inner values colored by type
+    pub fn colorize_value(&self, value: &CqlValue) -> String {
+        if !self.enabled {
+            return value.to_string();
+        }
+        self.colorize_value_inner(value)
+    }
+
+    /// Colorize a column header (magenta bold, matching Python cqlsh default).
+    pub fn colorize_header(&self, name: &str) -> String {
+        if !self.enabled {
+            return name.to_string();
+        }
+        format!("{}", name.magenta().bold())
+    }
+
+    /// Colorize an error message (red bold, matching Python cqlsh).
+    pub fn colorize_error(&self, msg: &str) -> String {
+        if !self.enabled {
+            return msg.to_string();
+        }
+        format!("{}", msg.red().bold())
+    }
+
+    /// Colorize a warning message (red bold, matching Python cqlsh).
+    pub fn colorize_warning(&self, msg: &str) -> String {
+        self.colorize_error(msg)
+    }
+
+    /// Colorize the "Tracing session:" label (magenta bold).
+    pub fn colorize_trace_label(&self, label: &str) -> String {
+        if !self.enabled {
+            return label.to_string();
+        }
+        format!("{}", label.magenta().bold())
+    }
+
+    /// Colorize the cluster name in the welcome message (blue bold).
+    pub fn colorize_cluster_name(&self, name: &str) -> String {
+        if !self.enabled {
+            return name.to_string();
+        }
+        format!("{}", name.blue().bold())
+    }
+
+    /// Inner recursive value colorizer.
+    fn colorize_value_inner(&self, value: &CqlValue) -> String {
+        match value {
+            CqlValue::Ascii(s) | CqlValue::Text(s) => {
+                format!("{}", s.as_str().yellow().bold())
+            }
+            CqlValue::Int(_)
+            | CqlValue::BigInt(_)
+            | CqlValue::SmallInt(_)
+            | CqlValue::TinyInt(_)
+            | CqlValue::Float(_)
+            | CqlValue::Double(_)
+            | CqlValue::Decimal(_)
+            | CqlValue::Varint(_)
+            | CqlValue::Counter(_)
+            | CqlValue::Boolean(_)
+            | CqlValue::Uuid(_)
+            | CqlValue::TimeUuid(_)
+            | CqlValue::Timestamp(_)
+            | CqlValue::Date(_)
+            | CqlValue::Time(_)
+            | CqlValue::Duration { .. }
+            | CqlValue::Inet(_) => {
+                format!("{}", value.to_string().green().bold())
+            }
+            CqlValue::Blob(_) => {
+                format!("{}", value.to_string().dark_magenta())
+            }
+            CqlValue::Null => {
+                format!("{}", "null".red().bold())
+            }
+            CqlValue::Unset => {
+                format!("{}", "<unset>".red().bold())
+            }
+            CqlValue::List(items) => {
+                let mut result = format!("{}", "[".blue().bold());
+                for (i, item) in items.iter().enumerate() {
+                    if i > 0 {
+                        result.push_str(&format!("{}", ", ".blue().bold()));
+                    }
+                    result.push_str(&self.colorize_collection_element(item));
+                }
+                result.push_str(&format!("{}", "]".blue().bold()));
+                result
+            }
+            CqlValue::Set(items) => {
+                let mut result = format!("{}", "{".blue().bold());
+                for (i, item) in items.iter().enumerate() {
+                    if i > 0 {
+                        result.push_str(&format!("{}", ", ".blue().bold()));
+                    }
+                    result.push_str(&self.colorize_collection_element(item));
+                }
+                result.push_str(&format!("{}", "}".blue().bold()));
+                result
+            }
+            CqlValue::Map(entries) => {
+                let mut result = format!("{}", "{".blue().bold());
+                for (i, (k, v)) in entries.iter().enumerate() {
+                    if i > 0 {
+                        result.push_str(&format!("{}", ", ".blue().bold()));
+                    }
+                    result.push_str(&self.colorize_collection_element(k));
+                    result.push_str(&format!("{}", ": ".blue().bold()));
+                    result.push_str(&self.colorize_collection_element(v));
+                }
+                result.push_str(&format!("{}", "}".blue().bold()));
+                result
+            }
+            CqlValue::Tuple(items) => {
+                let mut result = format!("{}", "(".blue().bold());
+                for (i, item) in items.iter().enumerate() {
+                    if i > 0 {
+                        result.push_str(&format!("{}", ", ".blue().bold()));
+                    }
+                    match item {
+                        Some(v) => result.push_str(&self.colorize_collection_element(v)),
+                        None => result.push_str(&format!("{}", "null".red().bold())),
+                    }
+                }
+                result.push_str(&format!("{}", ")".blue().bold()));
+                result
+            }
+            CqlValue::UserDefinedType { fields, .. } => {
+                let mut result = format!("{}", "{".blue().bold());
+                for (i, (name, val)) in fields.iter().enumerate() {
+                    if i > 0 {
+                        result.push_str(&format!("{}", ", ".blue().bold()));
+                    }
+                    // UDT field names are yellow (like text)
+                    result.push_str(&format!("{}", name.as_str().yellow().bold()));
+                    result.push_str(&format!("{}", ": ".blue().bold()));
+                    match val {
+                        Some(v) => result.push_str(&self.colorize_collection_element(v)),
+                        None => result.push_str(&format!("{}", "null".red().bold())),
+                    }
+                }
+                result.push_str(&format!("{}", "}".blue().bold()));
+                result
+            }
+        }
+    }
+
+    /// Colorize an element inside a collection, quoting strings like Display does.
+    fn colorize_collection_element(&self, value: &CqlValue) -> String {
+        match value {
+            CqlValue::Ascii(s) | CqlValue::Text(s) => {
+                // Inside collections, strings are quoted: 'value'
+                let quoted = format!("'{}'", s.replace('\'', "''"));
+                format!("{}", quoted.yellow().bold())
+            }
+            other => self.colorize_value_inner(other),
+        }
     }
 
     /// Colorize a line of CQL input for display.
@@ -205,5 +381,96 @@ mod tests {
                 window[1]
             );
         }
+    }
+
+    // --- Output coloring tests ---
+
+    #[test]
+    fn colorize_text_value_yellow() {
+        let c = CqlColorizer::new(true);
+        let output = c.colorize_value(&CqlValue::Text("hello".to_string()));
+        assert!(output.contains("\x1b["), "should contain ANSI codes");
+        assert!(output.contains("hello"));
+    }
+
+    #[test]
+    fn colorize_int_value_green() {
+        let c = CqlColorizer::new(true);
+        let output = c.colorize_value(&CqlValue::Int(42));
+        assert!(output.contains("\x1b["), "should contain ANSI codes");
+        assert!(output.contains("42"));
+    }
+
+    #[test]
+    fn colorize_null_value_red() {
+        let c = CqlColorizer::new(true);
+        let output = c.colorize_value(&CqlValue::Null);
+        assert!(output.contains("\x1b["), "should contain ANSI codes");
+        assert!(output.contains("null"));
+    }
+
+    #[test]
+    fn colorize_blob_value_dark_magenta() {
+        let c = CqlColorizer::new(true);
+        let output = c.colorize_value(&CqlValue::Blob(vec![0xde, 0xad]));
+        assert!(output.contains("\x1b["), "should contain ANSI codes");
+        assert!(output.contains("dead"));
+    }
+
+    #[test]
+    fn colorize_list_with_blue_delimiters() {
+        let c = CqlColorizer::new(true);
+        let list = CqlValue::List(vec![CqlValue::Int(1), CqlValue::Int(2)]);
+        let output = c.colorize_value(&list);
+        assert!(output.contains("\x1b["), "should contain ANSI codes");
+    }
+
+    #[test]
+    fn colorize_value_disabled_returns_plain() {
+        let c = CqlColorizer::new(false);
+        let output = c.colorize_value(&CqlValue::Text("hello".to_string()));
+        assert_eq!(output, "hello");
+    }
+
+    #[test]
+    fn colorize_header_magenta() {
+        let c = CqlColorizer::new(true);
+        let output = c.colorize_header("name");
+        assert!(output.contains("\x1b["), "should contain ANSI codes");
+        assert!(output.contains("name"));
+    }
+
+    #[test]
+    fn colorize_error_red() {
+        let c = CqlColorizer::new(true);
+        let output = c.colorize_error("SyntaxException: bad input");
+        assert!(output.contains("\x1b["), "should contain ANSI codes");
+        assert!(output.contains("SyntaxException"));
+    }
+
+    #[test]
+    fn colorize_map_with_colored_elements() {
+        let c = CqlColorizer::new(true);
+        let map = CqlValue::Map(vec![(
+            CqlValue::Text("key".to_string()),
+            CqlValue::Int(42),
+        )]);
+        let output = c.colorize_value(&map);
+        assert!(output.contains("\x1b["), "should contain ANSI codes");
+    }
+
+    #[test]
+    fn colorize_udt_field_names_yellow() {
+        let c = CqlColorizer::new(true);
+        let udt = CqlValue::UserDefinedType {
+            keyspace: "ks".to_string(),
+            type_name: "my_type".to_string(),
+            fields: vec![
+                ("name".to_string(), Some(CqlValue::Text("Alice".to_string()))),
+                ("age".to_string(), Some(CqlValue::Int(30))),
+            ],
+        };
+        let output = c.colorize_value(&udt);
+        assert!(output.contains("\x1b["), "should contain ANSI codes");
     }
 }

--- a/src/completer.rs
+++ b/src/completer.rs
@@ -1,0 +1,599 @@
+//! Tab completion for the CQL shell.
+//!
+//! Implements rustyline's `Completer`, `Helper`, `Hinter`, `Highlighter`, and
+//! `Validator` traits to provide context-aware tab completion in the REPL.
+//! Completions include CQL keywords, shell commands, schema objects (keyspaces,
+//! tables, columns), consistency levels, DESCRIBE sub-commands, and file paths.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use rustyline::completion::{Completer, Pair};
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
+use rustyline::validate::Validator;
+use rustyline::{Context, Helper};
+use tokio::runtime::Handle;
+use tokio::sync::RwLock;
+
+use crate::schema_cache::SchemaCache;
+
+/// CQL keywords that can start a statement.
+const CQL_KEYWORDS: &[&str] = &[
+    "ALTER", "APPLY", "BATCH", "BEGIN", "CREATE", "DELETE", "DESCRIBE", "DROP",
+    "GRANT", "INSERT", "LIST", "REVOKE", "SELECT", "TRUNCATE", "UPDATE", "USE",
+];
+
+/// CQL clause keywords used within statements.
+const CQL_CLAUSE_KEYWORDS: &[&str] = &[
+    "ADD", "AGGREGATE", "ALL", "ALLOW", "AND", "AS", "ASC", "AUTHORIZE",
+    "BATCH", "BY", "CALLED", "CLUSTERING", "COLUMN", "COMPACT", "CONTAINS",
+    "COUNT", "CUSTOM", "DELETE", "DESC", "DESCRIBE", "DISTINCT", "DROP",
+    "ENTRIES", "EXECUTE", "EXISTS", "FILTERING", "FINALFUNC", "FROM",
+    "FROZEN", "FULL", "FUNCTION", "FUNCTIONS", "IF", "IN", "INDEX",
+    "INITCOND", "INPUT", "INSERT", "INTO", "IS", "JSON", "KEY", "KEYS",
+    "KEYSPACE", "KEYSPACES", "LANGUAGE", "LIKE", "LIMIT", "LIST", "LOGIN",
+    "MAP", "MATERIALIZED", "MODIFY", "NAMESPACE", "NORECURSIVE", "NOT",
+    "NULL", "OF", "ON", "OR", "ORDER", "PARTITION", "PASSWORD", "PER",
+    "PERMISSION", "PERMISSIONS", "PRIMARY", "RENAME", "REPLACE", "RETURNS",
+    "REVOKE", "SCHEMA", "SELECT", "SET", "SFUNC", "STATIC", "STORAGE",
+    "STYPE", "SUPERUSER", "TABLE", "TABLES", "TEXT", "TIMESTAMP", "TO",
+    "TOKEN", "TRIGGER", "TRUNCATE", "TTL", "TUPLE", "TYPE", "UNLOGGED",
+    "UPDATE", "USER", "USERS", "USING", "VALUES", "VIEW", "WHERE", "WITH",
+    "WRITETIME",
+];
+
+/// Built-in shell commands.
+const SHELL_COMMANDS: &[&str] = &[
+    "CAPTURE", "CLEAR", "CLS", "CONSISTENCY", "COPY", "DESCRIBE", "DESC",
+    "EXIT", "EXPAND", "HELP", "LOGIN", "PAGING", "QUIT", "SERIAL", "SHOW",
+    "SOURCE", "TRACING",
+];
+
+/// CQL consistency levels.
+const CONSISTENCY_LEVELS: &[&str] = &[
+    "ALL", "ANY", "EACH_QUORUM", "LOCAL_ONE", "LOCAL_QUORUM", "LOCAL_SERIAL",
+    "ONE", "QUORUM", "SERIAL", "THREE", "TWO",
+];
+
+/// DESCRIBE sub-commands.
+const DESCRIBE_SUB_COMMANDS: &[&str] = &[
+    "AGGREGATE", "AGGREGATES", "CLUSTER", "FUNCTION", "FUNCTIONS", "INDEX",
+    "KEYSPACE", "KEYSPACES", "MATERIALIZED", "SCHEMA", "TABLE", "TABLES",
+    "TYPE", "TYPES",
+];
+
+/// CQL data types for CREATE TABLE column definitions.
+const CQL_TYPES: &[&str] = &[
+    "ascii", "bigint", "blob", "boolean", "counter", "date", "decimal",
+    "double", "duration", "float", "frozen", "inet", "int", "list", "map",
+    "set", "smallint", "text", "time", "timestamp", "timeuuid", "tinyint",
+    "tuple", "uuid", "varchar", "varint",
+];
+
+/// Detected completion context based on the input up to the cursor.
+#[derive(Debug, PartialEq)]
+enum CompletionContext {
+    /// At the start of input — complete with statement keywords and shell commands.
+    Empty,
+    /// After a statement keyword — complete with clause keywords.
+    ClauseKeyword,
+    /// After FROM, INTO, UPDATE, etc. — complete with table names.
+    TableName { keyspace: Option<String> },
+    /// After SELECT ... FROM table WHERE — complete with column names.
+    ColumnName { keyspace: Option<String>, table: String },
+    /// After CONSISTENCY — complete with consistency levels.
+    ConsistencyLevel,
+    /// After DESCRIBE/DESC — complete with sub-commands or schema names.
+    DescribeTarget,
+    /// After SOURCE or CAPTURE — complete with file paths.
+    FilePath,
+    /// In a CREATE TABLE column type position — complete with CQL types.
+    CqlType,
+    /// After USE — complete with keyspace names.
+    KeyspaceName,
+}
+
+/// Tab completer for the CQL shell REPL.
+pub struct CqlCompleter {
+    /// Shared schema cache for keyspace/table/column lookups.
+    cache: Arc<RwLock<SchemaCache>>,
+    /// Current keyspace (shared with session via USE command).
+    current_keyspace: Arc<RwLock<Option<String>>>,
+    /// Tokio runtime handle for blocking cache reads inside sync complete().
+    rt_handle: Handle,
+}
+
+impl CqlCompleter {
+    /// Create a new completer with shared cache and keyspace state.
+    pub fn new(
+        cache: Arc<RwLock<SchemaCache>>,
+        current_keyspace: Arc<RwLock<Option<String>>>,
+        rt_handle: Handle,
+    ) -> Self {
+        Self {
+            cache,
+            current_keyspace,
+            rt_handle,
+        }
+    }
+
+    /// Detect completion context from the input line up to the cursor position.
+    fn detect_context(&self, line: &str, pos: usize) -> CompletionContext {
+        let before_cursor = &line[..pos];
+        let tokens: Vec<&str> = before_cursor.split_whitespace().collect();
+
+        if tokens.is_empty() {
+            return CompletionContext::Empty;
+        }
+
+        let first = tokens[0].to_uppercase();
+
+        // CONSISTENCY <level>
+        if first == "CONSISTENCY" && tokens.len() <= 2 {
+            return if (tokens.len() == 1 && before_cursor.ends_with(' ')) || tokens.len() == 2 {
+                CompletionContext::ConsistencyLevel
+            } else {
+                CompletionContext::Empty
+            };
+        }
+
+        // SERIAL CONSISTENCY <level>
+        if first == "SERIAL" && tokens.len() >= 2 && tokens[1].to_uppercase() == "CONSISTENCY" {
+            return CompletionContext::ConsistencyLevel;
+        }
+
+        // SOURCE / CAPTURE — file path
+        if first == "SOURCE" || first == "CAPTURE" {
+            return CompletionContext::FilePath;
+        }
+
+        // USE <keyspace>
+        if first == "USE" {
+            return CompletionContext::KeyspaceName;
+        }
+
+        // DESCRIBE / DESC
+        if first == "DESCRIBE" || first == "DESC" {
+            if tokens.len() == 1 && before_cursor.ends_with(' ') {
+                return CompletionContext::DescribeTarget;
+            }
+            if tokens.len() == 2 {
+                let sub = tokens[1].to_uppercase();
+                if before_cursor.ends_with(' ') {
+                    // After sub-command, complete with schema names
+                    return match sub.as_str() {
+                        "KEYSPACE" => CompletionContext::KeyspaceName,
+                        "TABLE" | "INDEX" | "MATERIALIZED" => CompletionContext::TableName { keyspace: None },
+                        _ => CompletionContext::DescribeTarget,
+                    };
+                }
+                return CompletionContext::DescribeTarget;
+            }
+            if tokens.len() == 3 {
+                let sub = tokens[1].to_uppercase();
+                return match sub.as_str() {
+                    "KEYSPACE" => CompletionContext::KeyspaceName,
+                    "TABLE" | "INDEX" => CompletionContext::TableName { keyspace: None },
+                    _ => CompletionContext::ClauseKeyword,
+                };
+            }
+            return CompletionContext::ClauseKeyword;
+        }
+
+        // Check for FROM/INTO/UPDATE keywords to trigger table name completion
+        let upper_tokens: Vec<String> = tokens.iter().map(|t| t.to_uppercase()).collect();
+        for (i, token) in upper_tokens.iter().enumerate() {
+            if (token == "FROM" || token == "INTO" || token == "UPDATE" || token == "TABLE")
+                && i + 1 >= tokens.len()
+                && before_cursor.ends_with(' ')
+            {
+                return CompletionContext::TableName { keyspace: None };
+            }
+            if (token == "FROM" || token == "INTO" || token == "UPDATE" || token == "TABLE")
+                && i + 1 < tokens.len()
+            {
+                let table_token = tokens[i + 1];
+                // Check if partially typing a qualified name (ks.)
+                if table_token.contains('.') && table_token.ends_with('.') {
+                    let ks = table_token.trim_end_matches('.').to_string();
+                    return CompletionContext::TableName { keyspace: Some(ks) };
+                }
+                // If we're past the table name, might be column context
+                if i + 2 < tokens.len() || (i + 1 < tokens.len() && before_cursor.ends_with(' ')) {
+                    // Check for WHERE clause
+                    if upper_tokens.iter().skip(i + 2).any(|t| t == "WHERE" || t == "SET") {
+                        let table = tokens[i + 1].to_string();
+                        let ks = self.rt_handle.block_on(async {
+                            self.current_keyspace.read().await.clone()
+                        });
+                        return CompletionContext::ColumnName {
+                            keyspace: ks,
+                            table,
+                        };
+                    }
+                }
+                // Still typing the table name
+                if !before_cursor.ends_with(' ') && i + 1 == tokens.len() - 1 {
+                    return CompletionContext::TableName { keyspace: None };
+                }
+            }
+        }
+
+        // At beginning of line, completing a keyword
+        if tokens.len() == 1 && !before_cursor.ends_with(' ') {
+            return CompletionContext::Empty;
+        }
+
+        CompletionContext::ClauseKeyword
+    }
+
+    /// Generate completions for the detected context.
+    fn complete_for_context(&self, ctx: &CompletionContext, prefix: &str) -> Vec<Pair> {
+        let prefix_upper = prefix.to_uppercase();
+
+        match ctx {
+            CompletionContext::Empty => {
+                let mut candidates: Vec<&str> = Vec::new();
+                candidates.extend_from_slice(CQL_KEYWORDS);
+                candidates.extend_from_slice(SHELL_COMMANDS);
+                filter_candidates(&candidates, &prefix_upper, true)
+            }
+            CompletionContext::ClauseKeyword => {
+                filter_candidates(CQL_CLAUSE_KEYWORDS, &prefix_upper, true)
+            }
+            CompletionContext::ConsistencyLevel => {
+                filter_candidates(CONSISTENCY_LEVELS, &prefix_upper, true)
+            }
+            CompletionContext::DescribeTarget => {
+                filter_candidates(DESCRIBE_SUB_COMMANDS, &prefix_upper, true)
+            }
+            CompletionContext::CqlType => {
+                filter_candidates(CQL_TYPES, &prefix.to_lowercase(), false)
+            }
+            CompletionContext::KeyspaceName => {
+                let cache = self.rt_handle.block_on(self.cache.read());
+                let names = cache.keyspace_names();
+                filter_candidates(&names, prefix, false)
+            }
+            CompletionContext::TableName { keyspace } => {
+                let cache = self.rt_handle.block_on(self.cache.read());
+                let ks = keyspace.clone().or_else(|| {
+                    self.rt_handle.block_on(async {
+                        self.current_keyspace.read().await.clone()
+                    })
+                });
+                match ks {
+                    Some(ref ks_name) => {
+                        let names = cache.table_names(ks_name);
+                        filter_candidates(&names, prefix, false)
+                    }
+                    None => {
+                        // No keyspace context — offer keyspace names for qualification
+                        let names = cache.keyspace_names();
+                        filter_candidates(&names, prefix, false)
+                    }
+                }
+            }
+            CompletionContext::ColumnName { keyspace, table } => {
+                let cache = self.rt_handle.block_on(self.cache.read());
+                let ks = keyspace.clone().or_else(|| {
+                    self.rt_handle.block_on(async {
+                        self.current_keyspace.read().await.clone()
+                    })
+                });
+                match ks {
+                    Some(ref ks_name) => {
+                        let names = cache.column_names(ks_name, table);
+                        filter_candidates(&names, prefix, false)
+                    }
+                    None => vec![],
+                }
+            }
+            CompletionContext::FilePath => {
+                complete_file_path(prefix)
+            }
+        }
+    }
+}
+
+/// Filter candidates by prefix, returning matching `Pair`s.
+fn filter_candidates(candidates: &[&str], prefix: &str, uppercase: bool) -> Vec<Pair> {
+    candidates
+        .iter()
+        .filter(|c| {
+            if uppercase {
+                c.to_uppercase().starts_with(&prefix.to_uppercase())
+            } else {
+                c.starts_with(prefix)
+            }
+        })
+        .map(|c| {
+            let display = if uppercase { c.to_uppercase() } else { c.to_string() };
+            Pair {
+                display: display.clone(),
+                replacement: display,
+            }
+        })
+        .collect()
+}
+
+/// Complete file paths for SOURCE and CAPTURE commands.
+fn complete_file_path(prefix: &str) -> Vec<Pair> {
+    // Strip surrounding quotes if present
+    let path_str = prefix
+        .strip_prefix('\'')
+        .or_else(|| prefix.strip_prefix('"'))
+        .unwrap_or(prefix);
+
+    // Expand ~ to home directory
+    let expanded = if path_str.starts_with('~') {
+        if let Some(home) = dirs::home_dir() {
+            path_str.replacen('~', &home.to_string_lossy(), 1)
+        } else {
+            path_str.to_string()
+        }
+    } else {
+        path_str.to_string()
+    };
+
+    let (dir, file_prefix) = if expanded.ends_with('/') {
+        (expanded.as_str(), "")
+    } else {
+        let path = std::path::Path::new(&expanded);
+        let parent = path.parent().map(|p| p.to_str().unwrap_or(".")).unwrap_or(".");
+        let file = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
+        (parent, file)
+    };
+
+    let dir_to_read = if dir.is_empty() { "." } else { dir };
+
+    let Ok(entries) = std::fs::read_dir(dir_to_read) else {
+        return vec![];
+    };
+
+    entries
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with(file_prefix) {
+                let is_dir = entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
+                let suffix = if is_dir { "/" } else { "" };
+                let full = if dir.is_empty() || dir == "." {
+                    format!("{name}{suffix}")
+                } else if dir.ends_with('/') {
+                    format!("{dir}{name}{suffix}")
+                } else {
+                    format!("{dir}/{name}{suffix}")
+                };
+                Some(Pair {
+                    display: name + suffix,
+                    replacement: full,
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+impl Completer for CqlCompleter {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Pair>)> {
+        // Refresh cache if stale
+        let needs_refresh = self.rt_handle.block_on(async {
+            self.cache.read().await.is_stale()
+        });
+        if needs_refresh {
+            // Best-effort refresh — don't block on errors
+            let _ = self.rt_handle.block_on(async {
+                // Try to get write lock without blocking other completions
+                if let Ok(mut cache) = self.cache.try_write() {
+                    // Re-check staleness after acquiring lock
+                    if cache.is_stale() {
+                        // We can't refresh without a session reference here.
+                        // The REPL pre-refreshes the cache; this is a fallback mark.
+                        cache.invalidate();
+                    }
+                }
+            });
+        }
+
+        let context = self.detect_context(line, pos);
+
+        // Find the start of the word being completed
+        let before_cursor = &line[..pos];
+        let word_start = before_cursor
+            .rfind(|c: char| c.is_whitespace() || c == '.' || c == '\'' || c == '"')
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let prefix = &line[word_start..pos];
+
+        let completions = self.complete_for_context(&context, prefix);
+
+        Ok((word_start, completions))
+    }
+}
+
+impl Hinter for CqlCompleter {
+    type Hint = String;
+
+    fn hint(&self, _line: &str, _pos: usize, _ctx: &Context<'_>) -> Option<String> {
+        None
+    }
+}
+
+impl Highlighter for CqlCompleter {
+    fn highlight<'l>(&self, line: &'l str, _pos: usize) -> Cow<'l, str> {
+        // Highlighting will be added in Task 9
+        Cow::Borrowed(line)
+    }
+
+    fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
+        &'s self,
+        prompt: &'p str,
+        _default: bool,
+    ) -> Cow<'b, str> {
+        Cow::Borrowed(prompt)
+    }
+
+    fn highlight_char(&self, _line: &str, _pos: usize, _forced: rustyline::highlight::CmdKind) -> bool {
+        false
+    }
+}
+
+impl Validator for CqlCompleter {}
+
+impl Helper for CqlCompleter {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_completer() -> CqlCompleter {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let cache = Arc::new(RwLock::new(SchemaCache::new()));
+        let current_ks = Arc::new(RwLock::new(None::<String>));
+        CqlCompleter::new(cache, current_ks, rt.handle().clone())
+    }
+
+    #[test]
+    fn completer_can_be_created() {
+        let _c = make_completer();
+    }
+
+    #[test]
+    fn detect_empty_context() {
+        let c = make_completer();
+        assert_eq!(c.detect_context("", 0), CompletionContext::Empty);
+    }
+
+    #[test]
+    fn detect_keyword_prefix() {
+        let c = make_completer();
+        assert_eq!(c.detect_context("SEL", 3), CompletionContext::Empty);
+    }
+
+    #[test]
+    fn detect_consistency_context() {
+        let c = make_completer();
+        assert_eq!(
+            c.detect_context("CONSISTENCY ", 12),
+            CompletionContext::ConsistencyLevel
+        );
+    }
+
+    #[test]
+    fn detect_serial_consistency_context() {
+        let c = make_completer();
+        assert_eq!(
+            c.detect_context("SERIAL CONSISTENCY ", 19),
+            CompletionContext::ConsistencyLevel
+        );
+    }
+
+    #[test]
+    fn detect_use_keyspace_context() {
+        let c = make_completer();
+        assert_eq!(
+            c.detect_context("USE ", 4),
+            CompletionContext::KeyspaceName
+        );
+    }
+
+    #[test]
+    fn detect_describe_sub_command() {
+        let c = make_completer();
+        assert_eq!(
+            c.detect_context("DESCRIBE ", 9),
+            CompletionContext::DescribeTarget
+        );
+    }
+
+    #[test]
+    fn detect_describe_table_name() {
+        let c = make_completer();
+        assert_eq!(
+            c.detect_context("DESCRIBE TABLE ", 15),
+            CompletionContext::TableName { keyspace: None }
+        );
+    }
+
+    #[test]
+    fn detect_describe_keyspace_name() {
+        let c = make_completer();
+        assert_eq!(
+            c.detect_context("DESCRIBE KEYSPACE ", 18),
+            CompletionContext::KeyspaceName
+        );
+    }
+
+    #[test]
+    fn detect_source_file_path() {
+        let c = make_completer();
+        assert_eq!(
+            c.detect_context("SOURCE '/tmp/", 13),
+            CompletionContext::FilePath
+        );
+    }
+
+    #[test]
+    fn detect_capture_file_path() {
+        let c = make_completer();
+        assert_eq!(
+            c.detect_context("CAPTURE ", 8),
+            CompletionContext::FilePath
+        );
+    }
+
+    #[test]
+    fn detect_from_table_context() {
+        let c = make_completer();
+        assert_eq!(
+            c.detect_context("SELECT * FROM ", 14),
+            CompletionContext::TableName { keyspace: None }
+        );
+    }
+
+    #[test]
+    fn complete_keyword_prefix() {
+        let c = make_completer();
+        let pairs = c.complete_for_context(&CompletionContext::Empty, "SEL");
+        assert!(pairs.iter().any(|p| p.replacement == "SELECT"));
+    }
+
+    #[test]
+    fn complete_consistency_level_prefix() {
+        let c = make_completer();
+        let pairs = c.complete_for_context(&CompletionContext::ConsistencyLevel, "QU");
+        assert!(pairs.iter().any(|p| p.replacement == "QUORUM"));
+    }
+
+    #[test]
+    fn complete_describe_sub_command() {
+        let c = make_completer();
+        let pairs = c.complete_for_context(&CompletionContext::DescribeTarget, "KEY");
+        assert!(pairs.iter().any(|p| p.replacement == "KEYSPACE"));
+        assert!(pairs.iter().any(|p| p.replacement == "KEYSPACES"));
+    }
+
+    #[test]
+    fn filter_is_case_insensitive_for_keywords() {
+        let pairs = filter_candidates(CQL_KEYWORDS, "sel", true);
+        assert!(pairs.iter().any(|p| p.replacement == "SELECT"));
+    }
+
+    #[test]
+    fn file_path_completion_tmp() {
+        // /tmp should exist on all Unix systems
+        let pairs = complete_file_path("/tmp/");
+        // Should return entries — exact count varies
+        assert!(!pairs.is_empty() || std::fs::read_dir("/tmp").map(|d| d.count()).unwrap_or(0) == 0);
+    }
+}

--- a/src/completer.rs
+++ b/src/completer.rs
@@ -16,6 +16,7 @@ use rustyline::{Context, Helper};
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
 
+use crate::colorizer::CqlColorizer;
 use crate::schema_cache::SchemaCache;
 
 /// CQL keywords that can start a statement.
@@ -102,6 +103,8 @@ pub struct CqlCompleter {
     current_keyspace: Arc<RwLock<Option<String>>>,
     /// Tokio runtime handle for blocking cache reads inside sync complete().
     rt_handle: Handle,
+    /// Syntax colorizer for highlighting.
+    colorizer: CqlColorizer,
 }
 
 impl CqlCompleter {
@@ -110,11 +113,13 @@ impl CqlCompleter {
         cache: Arc<RwLock<SchemaCache>>,
         current_keyspace: Arc<RwLock<Option<String>>>,
         rt_handle: Handle,
+        color_enabled: bool,
     ) -> Self {
         Self {
             cache,
             current_keyspace,
             rt_handle,
+            colorizer: CqlColorizer::new(color_enabled),
         }
     }
 
@@ -431,8 +436,12 @@ impl Hinter for CqlCompleter {
 
 impl Highlighter for CqlCompleter {
     fn highlight<'l>(&self, line: &'l str, _pos: usize) -> Cow<'l, str> {
-        // Highlighting will be added in Task 9
-        Cow::Borrowed(line)
+        let colored = self.colorizer.colorize_line(line);
+        if colored == line {
+            Cow::Borrowed(line)
+        } else {
+            Cow::Owned(colored)
+        }
     }
 
     fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
@@ -444,7 +453,8 @@ impl Highlighter for CqlCompleter {
     }
 
     fn highlight_char(&self, _line: &str, _pos: usize, _forced: rustyline::highlight::CmdKind) -> bool {
-        false
+        // Return true to trigger re-highlighting on every keystroke
+        true
     }
 }
 
@@ -460,7 +470,7 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let cache = Arc::new(RwLock::new(SchemaCache::new()));
         let current_ks = Arc::new(RwLock::new(None::<String>));
-        CqlCompleter::new(cache, current_ks, rt.handle().clone())
+        CqlCompleter::new(cache, current_ks, rt.handle().clone(), false)
     }
 
     #[test]

--- a/src/completer.rs
+++ b/src/completer.rs
@@ -65,6 +65,7 @@ const DESCRIBE_SUB_COMMANDS: &[&str] = &[
 ];
 
 /// CQL data types for CREATE TABLE column definitions.
+#[allow(dead_code)] // Will be used when CqlType completion context is implemented
 const CQL_TYPES: &[&str] = &[
     "ascii", "bigint", "blob", "boolean", "counter", "date", "decimal",
     "double", "duration", "float", "frozen", "inet", "int", "list", "map",
@@ -89,8 +90,6 @@ enum CompletionContext {
     DescribeTarget,
     /// After SOURCE or CAPTURE — complete with file paths.
     FilePath,
-    /// In a CREATE TABLE column type position — complete with CQL types.
-    CqlType,
     /// After USE — complete with keyspace names.
     KeyspaceName,
 }
@@ -209,8 +208,10 @@ impl CqlCompleter {
                     // Check for WHERE clause
                     if upper_tokens.iter().skip(i + 2).any(|t| t == "WHERE" || t == "SET") {
                         let table = tokens[i + 1].to_string();
-                        let ks = self.rt_handle.block_on(async {
-                            self.current_keyspace.read().await.clone()
+                        let ks = tokio::task::block_in_place(|| {
+                            self.rt_handle.block_on(async {
+                                self.current_keyspace.read().await.clone()
+                            })
                         });
                         return CompletionContext::ColumnName {
                             keyspace: ks,
@@ -253,19 +254,22 @@ impl CqlCompleter {
             CompletionContext::DescribeTarget => {
                 filter_candidates(DESCRIBE_SUB_COMMANDS, &prefix_upper, true)
             }
-            CompletionContext::CqlType => {
-                filter_candidates(CQL_TYPES, &prefix.to_lowercase(), false)
-            }
             CompletionContext::KeyspaceName => {
-                let cache = self.rt_handle.block_on(self.cache.read());
+                let cache = tokio::task::block_in_place(|| {
+                    self.rt_handle.block_on(self.cache.read())
+                });
                 let names = cache.keyspace_names();
                 filter_candidates(&names, prefix, false)
             }
             CompletionContext::TableName { keyspace } => {
-                let cache = self.rt_handle.block_on(self.cache.read());
+                let cache = tokio::task::block_in_place(|| {
+                    self.rt_handle.block_on(self.cache.read())
+                });
                 let ks = keyspace.clone().or_else(|| {
-                    self.rt_handle.block_on(async {
-                        self.current_keyspace.read().await.clone()
+                    tokio::task::block_in_place(|| {
+                        self.rt_handle.block_on(async {
+                            self.current_keyspace.read().await.clone()
+                        })
                     })
                 });
                 match ks {
@@ -281,10 +285,14 @@ impl CqlCompleter {
                 }
             }
             CompletionContext::ColumnName { keyspace, table } => {
-                let cache = self.rt_handle.block_on(self.cache.read());
+                let cache = tokio::task::block_in_place(|| {
+                    self.rt_handle.block_on(self.cache.read())
+                });
                 let ks = keyspace.clone().or_else(|| {
-                    self.rt_handle.block_on(async {
-                        self.current_keyspace.read().await.clone()
+                    tokio::task::block_in_place(|| {
+                        self.rt_handle.block_on(async {
+                            self.current_keyspace.read().await.clone()
+                        })
                     })
                 });
                 match ks {
@@ -391,22 +399,26 @@ impl Completer for CqlCompleter {
         pos: usize,
         _ctx: &Context<'_>,
     ) -> rustyline::Result<(usize, Vec<Pair>)> {
-        // Refresh cache if stale
-        let needs_refresh = self.rt_handle.block_on(async {
-            self.cache.read().await.is_stale()
+        // block_in_place: complete() is called from within the Tokio runtime (sync rustyline trait)
+        let needs_refresh = tokio::task::block_in_place(|| {
+            self.rt_handle.block_on(async {
+                self.cache.read().await.is_stale()
+            })
         });
         if needs_refresh {
             // Best-effort refresh — don't block on errors
-            let _ = self.rt_handle.block_on(async {
-                // Try to get write lock without blocking other completions
-                if let Ok(mut cache) = self.cache.try_write() {
-                    // Re-check staleness after acquiring lock
-                    if cache.is_stale() {
-                        // We can't refresh without a session reference here.
-                        // The REPL pre-refreshes the cache; this is a fallback mark.
-                        cache.invalidate();
+            tokio::task::block_in_place(|| {
+                self.rt_handle.block_on(async {
+                    // Try to get write lock without blocking other completions
+                    if let Ok(mut cache) = self.cache.try_write() {
+                        // Re-check staleness after acquiring lock
+                        if cache.is_stale() {
+                            // We can't refresh without a session reference here.
+                            // The REPL pre-refreshes the cache; this is a fallback mark.
+                            cache.invalidate();
+                        }
                     }
-                }
+                })
             });
         }
 

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -84,6 +84,33 @@ pub struct TableMetadata {
     pub clustering_key: Vec<String>,
 }
 
+/// Metadata about a user-defined type (UDT).
+#[derive(Debug, Clone)]
+pub struct UdtMetadata {
+    pub keyspace: String,
+    pub name: String,
+    pub field_names: Vec<String>,
+    pub field_types: Vec<String>,
+}
+
+/// Metadata about a user-defined function (UDF).
+#[derive(Debug, Clone)]
+pub struct FunctionMetadata {
+    pub keyspace: String,
+    pub name: String,
+    pub argument_types: Vec<String>,
+    pub return_type: String,
+}
+
+/// Metadata about a user-defined aggregate (UDA).
+#[derive(Debug, Clone)]
+pub struct AggregateMetadata {
+    pub keyspace: String,
+    pub name: String,
+    pub argument_types: Vec<String>,
+    pub return_type: String,
+}
+
 /// Consistency levels matching CQL specification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Consistency {
@@ -210,6 +237,15 @@ pub trait CqlDriver: Send + Sync {
         table: &str,
     ) -> Result<Option<TableMetadata>>;
 
+    /// Get metadata for all user-defined types in a keyspace.
+    async fn get_udts(&self, keyspace: &str) -> Result<Vec<UdtMetadata>>;
+
+    /// Get metadata for all user-defined functions in a keyspace.
+    async fn get_functions(&self, keyspace: &str) -> Result<Vec<FunctionMetadata>>;
+
+    /// Get metadata for all user-defined aggregates in a keyspace.
+    async fn get_aggregates(&self, keyspace: &str) -> Result<Vec<AggregateMetadata>>;
+
     /// Get the cluster name.
     async fn get_cluster_name(&self) -> Result<Option<String>>;
 
@@ -259,6 +295,86 @@ pub struct TracingEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn udt_metadata_fields() {
+        let udt = UdtMetadata {
+            keyspace: "ks".to_string(),
+            name: "address".to_string(),
+            field_names: vec!["street".to_string(), "city".to_string()],
+            field_types: vec!["text".to_string(), "text".to_string()],
+        };
+        assert_eq!(udt.keyspace, "ks");
+        assert_eq!(udt.name, "address");
+        assert_eq!(udt.field_names.len(), 2);
+        assert_eq!(udt.field_types.len(), 2);
+        assert_eq!(udt.field_names[0], "street");
+        assert_eq!(udt.field_types[0], "text");
+    }
+
+    #[test]
+    fn function_metadata_fields() {
+        let func = FunctionMetadata {
+            keyspace: "ks".to_string(),
+            name: "my_func".to_string(),
+            argument_types: vec!["int".to_string(), "text".to_string()],
+            return_type: "boolean".to_string(),
+        };
+        assert_eq!(func.keyspace, "ks");
+        assert_eq!(func.name, "my_func");
+        assert_eq!(func.argument_types, vec!["int", "text"]);
+        assert_eq!(func.return_type, "boolean");
+    }
+
+    #[test]
+    fn aggregate_metadata_fields() {
+        let agg = AggregateMetadata {
+            keyspace: "ks".to_string(),
+            name: "my_agg".to_string(),
+            argument_types: vec!["int".to_string()],
+            return_type: "bigint".to_string(),
+        };
+        assert_eq!(agg.keyspace, "ks");
+        assert_eq!(agg.name, "my_agg");
+        assert_eq!(agg.argument_types, vec!["int"]);
+        assert_eq!(agg.return_type, "bigint");
+    }
+
+    #[test]
+    fn udt_metadata_clone() {
+        let udt = UdtMetadata {
+            keyspace: "ks".to_string(),
+            name: "my_type".to_string(),
+            field_names: vec!["f1".to_string()],
+            field_types: vec!["int".to_string()],
+        };
+        let cloned = udt.clone();
+        assert_eq!(cloned.keyspace, udt.keyspace);
+        assert_eq!(cloned.name, udt.name);
+    }
+
+    #[test]
+    fn function_metadata_empty_args() {
+        let func = FunctionMetadata {
+            keyspace: "ks".to_string(),
+            name: "no_args_func".to_string(),
+            argument_types: vec![],
+            return_type: "text".to_string(),
+        };
+        assert!(func.argument_types.is_empty());
+    }
+
+    #[test]
+    fn aggregate_metadata_clone() {
+        let agg = AggregateMetadata {
+            keyspace: "ks".to_string(),
+            name: "my_agg".to_string(),
+            argument_types: vec!["int".to_string()],
+            return_type: "bigint".to_string(),
+        };
+        let cloned = agg.clone();
+        assert_eq!(cloned.return_type, agg.return_type);
+    }
 
     #[test]
     fn consistency_from_str() {

--- a/src/driver/scylla_driver.rs
+++ b/src/driver/scylla_driver.rs
@@ -22,8 +22,9 @@ use uuid::Uuid;
 
 use super::types::{CqlColumn, CqlResult, CqlRow, CqlValue};
 use super::{
-    ColumnMetadata, ConnectionConfig, Consistency, CqlDriver, KeyspaceMetadata, PreparedId,
-    SslConfig, TableMetadata, TracingEvent, TracingSession,
+    AggregateMetadata, ColumnMetadata, ConnectionConfig, Consistency, CqlDriver, FunctionMetadata,
+    KeyspaceMetadata, PreparedId, SslConfig, TableMetadata, TracingEvent, TracingSession,
+    UdtMetadata,
 };
 
 /// ScyllaDriver wraps a scylla `Session` and provides the `CqlDriver` trait.
@@ -631,6 +632,18 @@ impl CqlDriver for ScyllaDriver {
     ) -> Result<Option<TableMetadata>> {
         let tables = self.get_tables(keyspace).await?;
         Ok(tables.into_iter().find(|t| t.name == table))
+    }
+
+    async fn get_udts(&self, _keyspace: &str) -> Result<Vec<UdtMetadata>> {
+        Ok(vec![])
+    }
+
+    async fn get_functions(&self, _keyspace: &str) -> Result<Vec<FunctionMetadata>> {
+        Ok(vec![])
+    }
+
+    async fn get_aggregates(&self, _keyspace: &str) -> Result<Vec<AggregateMetadata>> {
+        Ok(vec![])
     }
 
     async fn get_cluster_name(&self) -> Result<Option<String>> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -93,6 +93,12 @@ pub fn format_error(error: &anyhow::Error) -> String {
     format!("{}: {}", classified.category, classified.message)
 }
 
+/// Format a classified error with optional color (red bold when enabled).
+pub fn format_error_colored(error: &anyhow::Error, colorizer: &crate::colorizer::CqlColorizer) -> String {
+    let plain = format_error(error);
+    colorizer.colorize_error(&plain)
+}
+
 fn categorize_db_error(db_error: &DbError) -> ErrorCategory {
     match db_error {
         DbError::SyntaxError => ErrorCategory::SyntaxException,

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -6,9 +6,10 @@
 
 use std::io::{self, Read, Write};
 
-use comfy_table::{Attribute, Cell, CellAlignment, ContentArrangement, Table};
+use comfy_table::{Cell, CellAlignment, ContentArrangement, Table};
 use terminal_size::{terminal_size, Width};
 
+use crate::colorizer::CqlColorizer;
 use crate::driver::CqlResult;
 
 fn terminal_width() -> Option<u16> {
@@ -19,7 +20,8 @@ fn terminal_width() -> Option<u16> {
 ///
 /// Uses comfy-table for proper column alignment and Unicode box-drawing.
 /// Matches Python cqlsh output style with column headers and row counts.
-pub fn print_tabular(result: &CqlResult, writer: &mut dyn Write) {
+/// When a colorizer is provided, values and headers are colored.
+pub fn print_tabular(result: &CqlResult, colorizer: &CqlColorizer, writer: &mut dyn Write) {
     if result.columns.is_empty() {
         return;
     }
@@ -38,22 +40,22 @@ pub fn print_tabular(result: &CqlResult, writer: &mut dyn Write) {
     // Disable borders to match Python cqlsh's simple pipe-separated output
     table.load_preset(CQLSH_PRESET);
 
-    // Add header row
+    // Add header row (magenta bold when colored, plain bold otherwise)
     let headers: Vec<Cell> = result
         .columns
         .iter()
-        .map(|c| Cell::new(&c.name).add_attribute(Attribute::Bold))
+        .map(|c| Cell::new(colorizer.colorize_header(&c.name)))
         .collect();
     table.set_header(headers);
 
-    // Add data rows with type-aware alignment
+    // Add data rows with type-aware alignment and coloring
     for row in &result.rows {
         let cells: Vec<Cell> = row
             .values
             .iter()
             .enumerate()
             .map(|(i, val)| {
-                let display = val.to_string();
+                let display = colorizer.colorize_value(val);
                 let mut cell = Cell::new(display);
                 // Right-align numeric types to match Python cqlsh
                 if is_numeric_type(&result.columns[i].type_name) {
@@ -83,7 +85,7 @@ pub fn print_tabular(result: &CqlResult, writer: &mut dyn Write) {
 ///
 /// Each row is printed as a block with `@ Row N` header, followed by
 /// column_name | value pairs. Matches Python cqlsh `EXPAND ON` behavior.
-pub fn print_expanded(result: &CqlResult, writer: &mut dyn Write) {
+pub fn print_expanded(result: &CqlResult, colorizer: &CqlColorizer, writer: &mut dyn Write) {
     if result.columns.is_empty() {
         return;
     }
@@ -108,12 +110,12 @@ pub fn print_expanded(result: &CqlResult, writer: &mut dyn Write) {
         for (col_idx, col) in result.columns.iter().enumerate() {
             let value = row
                 .get(col_idx)
-                .map(|v| v.to_string())
-                .unwrap_or_else(|| "null".to_string());
+                .map(|v| colorizer.colorize_value(v))
+                .unwrap_or_else(|| colorizer.colorize_value(&crate::driver::types::CqlValue::Null));
             writeln!(
                 writer,
                 " {:>width$} | {}",
-                col.name,
+                colorizer.colorize_header(&col.name),
                 value,
                 width = max_col_width
             )
@@ -137,41 +139,26 @@ pub fn print_expanded(result: &CqlResult, writer: &mut dyn Write) {
 ///
 /// Shows a `---MORE---` prompt between pages. The user can press any key
 /// to continue, or 'q' to stop.
-pub fn print_paged(result: &CqlResult, page_size: usize, expand: bool, writer: &mut dyn Write) {
+pub fn print_paged(result: &CqlResult, page_size: usize, expand: bool, colorizer: &CqlColorizer, writer: &mut dyn Write) {
     if result.columns.is_empty() {
         return;
     }
 
     if expand {
         // For expanded output, page by row count
-        print_expanded_paged(result, page_size, writer);
+        print_expanded_paged(result, page_size, colorizer, writer);
     } else {
-        print_tabular_paged(result, page_size, writer);
+        print_tabular_paged(result, page_size, colorizer, writer);
     }
 }
 
 /// Print tabular output with pagination.
-fn print_tabular_paged(result: &CqlResult, page_size: usize, writer: &mut dyn Write) {
+fn print_tabular_paged(result: &CqlResult, page_size: usize, colorizer: &CqlColorizer, writer: &mut dyn Write) {
     let total_rows = result.rows.len();
     if total_rows <= page_size {
-        print_tabular(result, writer);
+        print_tabular(result, colorizer, writer);
         return;
     }
-
-    // Print header once
-    let mut table = Table::new();
-    table.set_content_arrangement(ContentArrangement::Dynamic);
-    if let Some(w) = terminal_width() {
-        table.set_width(w);
-    }
-    table.load_preset(CQLSH_PRESET);
-
-    let headers: Vec<Cell> = result
-        .columns
-        .iter()
-        .map(|c| Cell::new(&c.name).add_attribute(Attribute::Bold))
-        .collect();
-    table.set_header(headers);
 
     // Build the full table to get the header, then print rows page by page
     for (chunk_idx, chunk) in result.rows.chunks(page_size).enumerate() {
@@ -190,7 +177,7 @@ fn print_tabular_paged(result: &CqlResult, page_size: usize, writer: &mut dyn Wr
             let headers: Vec<Cell> = result
                 .columns
                 .iter()
-                .map(|c| Cell::new(&c.name).add_attribute(Attribute::Bold))
+                .map(|c| Cell::new(colorizer.colorize_header(&c.name)))
                 .collect();
             page_table.set_header(headers);
             writeln!(writer).ok();
@@ -202,7 +189,7 @@ fn print_tabular_paged(result: &CqlResult, page_size: usize, writer: &mut dyn Wr
                 .iter()
                 .enumerate()
                 .map(|(i, val)| {
-                    let display = val.to_string();
+                    let display = colorizer.colorize_value(val);
                     let mut cell = Cell::new(display);
                     if is_numeric_type(&result.columns[i].type_name) {
                         cell = cell.set_alignment(CellAlignment::Right);
@@ -229,10 +216,10 @@ fn print_tabular_paged(result: &CqlResult, page_size: usize, writer: &mut dyn Wr
 }
 
 /// Print expanded output with pagination.
-fn print_expanded_paged(result: &CqlResult, page_size: usize, writer: &mut dyn Write) {
+fn print_expanded_paged(result: &CqlResult, page_size: usize, colorizer: &CqlColorizer, writer: &mut dyn Write) {
     let total_rows = result.rows.len();
     if total_rows <= page_size {
-        print_expanded(result, writer);
+        print_expanded(result, colorizer, writer);
         return;
     }
 
@@ -255,12 +242,12 @@ fn print_expanded_paged(result: &CqlResult, page_size: usize, writer: &mut dyn W
         for (col_idx, col) in result.columns.iter().enumerate() {
             let value = row
                 .get(col_idx)
-                .map(|v| v.to_string())
-                .unwrap_or_else(|| "null".to_string());
+                .map(|v| colorizer.colorize_value(v))
+                .unwrap_or_else(|| colorizer.colorize_value(&crate::driver::types::CqlValue::Null));
             writeln!(
                 writer,
                 " {:>width$} | {}",
-                col.name,
+                colorizer.colorize_header(&col.name),
                 value,
                 width = max_col_width
             )
@@ -306,9 +293,15 @@ fn show_more_prompt() -> bool {
 /// Format tracing session output matching Python cqlsh style.
 ///
 /// Displays session metadata and a table of trace events sorted by elapsed time.
-pub fn print_trace(trace: &crate::driver::TracingSession, writer: &mut dyn Write) {
+pub fn print_trace(trace: &crate::driver::TracingSession, colorizer: &CqlColorizer, writer: &mut dyn Write) {
     writeln!(writer).ok();
-    writeln!(writer, "Tracing session: {}", trace.trace_id).ok();
+    writeln!(
+        writer,
+        "{} {}",
+        colorizer.colorize_trace_label("Tracing session:"),
+        trace.trace_id
+    )
+    .ok();
     writeln!(writer).ok();
 
     if let Some(ref request) = trace.request {
@@ -334,11 +327,11 @@ pub fn print_trace(trace: &crate::driver::TracingSession, writer: &mut dyn Write
         }
         table.load_preset(CQLSH_PRESET);
         table.set_header(vec![
-            Cell::new("activity").add_attribute(Attribute::Bold),
-            Cell::new("timestamp").add_attribute(Attribute::Bold),
-            Cell::new("source").add_attribute(Attribute::Bold),
-            Cell::new("source_elapsed").add_attribute(Attribute::Bold),
-            Cell::new("thread").add_attribute(Attribute::Bold),
+            Cell::new(colorizer.colorize_header("activity")),
+            Cell::new(colorizer.colorize_header("timestamp")),
+            Cell::new(colorizer.colorize_header("source")),
+            Cell::new(colorizer.colorize_header("source_elapsed")),
+            Cell::new(colorizer.colorize_header("thread")),
         ]);
 
         for event in &trace.events {
@@ -408,6 +401,10 @@ mod tests {
     use super::*;
     use crate::driver::types::{CqlColumn, CqlResult, CqlRow, CqlValue};
 
+    fn no_color() -> CqlColorizer {
+        CqlColorizer::new(false)
+    }
+
     fn sample_result() -> CqlResult {
         CqlResult {
             columns: vec![
@@ -438,7 +435,7 @@ mod tests {
     fn tabular_output_contains_headers_and_rows() {
         let result = sample_result();
         let mut buf = Vec::new();
-        print_tabular(&result, &mut buf);
+        print_tabular(&result, &no_color(), &mut buf);
         let output = String::from_utf8(buf).unwrap();
         assert!(output.contains("name"));
         assert!(output.contains("age"));
@@ -451,7 +448,7 @@ mod tests {
     fn expanded_output_shows_row_headers() {
         let result = sample_result();
         let mut buf = Vec::new();
-        print_expanded(&result, &mut buf);
+        print_expanded(&result, &no_color(), &mut buf);
         let output = String::from_utf8(buf).unwrap();
         assert!(output.contains("@ Row 1"));
         assert!(output.contains("@ Row 2"));
@@ -463,7 +460,7 @@ mod tests {
     fn tabular_empty_result_produces_no_output() {
         let result = CqlResult::empty();
         let mut buf = Vec::new();
-        print_tabular(&result, &mut buf);
+        print_tabular(&result, &no_color(), &mut buf);
         assert!(buf.is_empty());
     }
 
@@ -482,7 +479,7 @@ mod tests {
             warnings: vec![],
         };
         let mut buf = Vec::new();
-        print_tabular(&result, &mut buf);
+        print_tabular(&result, &no_color(), &mut buf);
         let output = String::from_utf8(buf).unwrap();
         assert!(output.contains("(1 row)"));
         assert!(!output.contains("(1 rows)"));
@@ -504,7 +501,7 @@ mod tests {
     fn tabular_row_separators_not_pipes() {
         let result = sample_result();
         let mut buf = Vec::new();
-        print_tabular(&result, &mut buf);
+        print_tabular(&result, &no_color(), &mut buf);
         let output = String::from_utf8(buf).unwrap();
         // Bug: row separators were `||||` instead of proper formatting.
         // The header separator should use `-` and `+`, not `|`.
@@ -517,7 +514,7 @@ mod tests {
     fn tabular_columns_separated_by_pipes() {
         let result = sample_result();
         let mut buf = Vec::new();
-        print_tabular(&result, &mut buf);
+        print_tabular(&result, &no_color(), &mut buf);
         let output = String::from_utf8(buf).unwrap();
         // Data rows should have `|` as column separator
         assert!(output.contains("| "), "columns should be separated by pipes");
@@ -546,7 +543,7 @@ mod tests {
         };
 
         let mut buf = Vec::new();
-        print_trace(&trace, &mut buf);
+        print_trace(&trace, &no_color(), &mut buf);
         let output = String::from_utf8(buf).unwrap();
         assert!(output.contains("Tracing session:"));
         assert!(output.contains("SELECT * FROM test"));

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,25 +1,20 @@
 //! Output formatting for CQL query results.
 //!
-//! Provides type-aware tabular formatting using comfy-table, expanded (vertical)
-//! output mode, and pagination with a `--More--` prompt. Mirrors the Python cqlsh
-//! output formatting behavior.
+//! Provides type-aware tabular formatting using comfy-table and expanded (vertical)
+//! output mode. Paging is handled externally by the `minus` pager crate.
+//! Mirrors the Python cqlsh output formatting behavior.
 
-use std::io::{self, Read, Write};
+use std::io::Write;
 
 use comfy_table::{Cell, CellAlignment, ContentArrangement, Table};
-use terminal_size::{terminal_size, Width};
 
 use crate::colorizer::CqlColorizer;
 use crate::driver::CqlResult;
 
-fn terminal_width() -> Option<u16> {
-    terminal_size().map(|(Width(w), _)| w)
-}
-
 /// Format and print query results in tabular format.
 ///
-/// Uses comfy-table for proper column alignment and Unicode box-drawing.
-/// Matches Python cqlsh output style with column headers and row counts.
+/// Uses comfy-table for proper column alignment. Columns render at natural width
+/// (no terminal width constraint) — the pager handles horizontal scrolling.
 /// When a colorizer is provided, values and headers are colored.
 pub fn print_tabular(result: &CqlResult, colorizer: &CqlColorizer, writer: &mut dyn Write) {
     if result.columns.is_empty() {
@@ -32,12 +27,7 @@ pub fn print_tabular(result: &CqlResult, colorizer: &CqlColorizer, writer: &mut 
     }
 
     let mut table = Table::new();
-    table.set_content_arrangement(ContentArrangement::Dynamic);
-    if let Some(w) = terminal_width() {
-        table.set_width(w);
-    }
-
-    // Disable borders to match Python cqlsh's simple pipe-separated output
+    table.set_content_arrangement(ContentArrangement::Disabled);
     table.load_preset(CQLSH_PRESET);
 
     // Add header row (magenta bold when colored, plain bold otherwise)
@@ -135,161 +125,6 @@ pub fn print_expanded(result: &CqlResult, colorizer: &CqlColorizer, writer: &mut
     writeln!(writer).ok();
 }
 
-/// Display results with pagination, pausing every `page_size` rows.
-///
-/// Shows a `---MORE---` prompt between pages. The user can press any key
-/// to continue, or 'q' to stop.
-pub fn print_paged(result: &CqlResult, page_size: usize, expand: bool, colorizer: &CqlColorizer, writer: &mut dyn Write) {
-    if result.columns.is_empty() {
-        return;
-    }
-
-    if expand {
-        // For expanded output, page by row count
-        print_expanded_paged(result, page_size, colorizer, writer);
-    } else {
-        print_tabular_paged(result, page_size, colorizer, writer);
-    }
-}
-
-/// Print tabular output with pagination.
-fn print_tabular_paged(result: &CqlResult, page_size: usize, colorizer: &CqlColorizer, writer: &mut dyn Write) {
-    let total_rows = result.rows.len();
-    if total_rows <= page_size {
-        print_tabular(result, colorizer, writer);
-        return;
-    }
-
-    // Build the full table to get the header, then print rows page by page
-    for (chunk_idx, chunk) in result.rows.chunks(page_size).enumerate() {
-        if chunk_idx > 0 && !show_more_prompt() {
-            break;
-        }
-
-        let mut page_table = Table::new();
-        page_table.set_content_arrangement(ContentArrangement::Dynamic);
-        if let Some(w) = terminal_width() {
-            page_table.set_width(w);
-        }
-        page_table.load_preset(CQLSH_PRESET);
-
-        if chunk_idx == 0 {
-            let headers: Vec<Cell> = result
-                .columns
-                .iter()
-                .map(|c| Cell::new(colorizer.colorize_header(&c.name)))
-                .collect();
-            page_table.set_header(headers);
-            writeln!(writer).ok();
-        }
-
-        for row in chunk {
-            let cells: Vec<Cell> = row
-                .values
-                .iter()
-                .enumerate()
-                .map(|(i, val)| {
-                    let display = colorizer.colorize_value(val);
-                    let mut cell = Cell::new(display);
-                    if is_numeric_type(&result.columns[i].type_name) {
-                        cell = cell.set_alignment(CellAlignment::Right);
-                    }
-                    cell
-                })
-                .collect();
-            page_table.add_row(cells);
-        }
-
-        writeln!(writer, "{page_table}").ok();
-    }
-
-    writeln!(writer).ok();
-    let row_count = result.rows.len();
-    writeln!(
-        writer,
-        "({} row{})",
-        row_count,
-        if row_count == 1 { "" } else { "s" }
-    )
-    .ok();
-    writeln!(writer).ok();
-}
-
-/// Print expanded output with pagination.
-fn print_expanded_paged(result: &CqlResult, page_size: usize, colorizer: &CqlColorizer, writer: &mut dyn Write) {
-    let total_rows = result.rows.len();
-    if total_rows <= page_size {
-        print_expanded(result, colorizer, writer);
-        return;
-    }
-
-    let max_col_width = result
-        .columns
-        .iter()
-        .map(|c| c.name.len())
-        .max()
-        .unwrap_or(0);
-
-    writeln!(writer).ok();
-
-    for (row_idx, row) in result.rows.iter().enumerate() {
-        if row_idx > 0 && row_idx % page_size == 0 && !show_more_prompt() {
-            break;
-        }
-
-        writeln!(writer, "@ Row {}", row_idx + 1).ok();
-        writeln!(writer, "{}", "-".repeat(max_col_width + 10)).ok();
-        for (col_idx, col) in result.columns.iter().enumerate() {
-            let value = row
-                .get(col_idx)
-                .map(|v| colorizer.colorize_value(v))
-                .unwrap_or_else(|| colorizer.colorize_value(&crate::driver::types::CqlValue::Null));
-            writeln!(
-                writer,
-                " {:>width$} | {}",
-                colorizer.colorize_header(&col.name),
-                value,
-                width = max_col_width
-            )
-            .ok();
-        }
-        writeln!(writer).ok();
-    }
-
-    let row_count = result.rows.len();
-    writeln!(
-        writer,
-        "({} row{})",
-        row_count,
-        if row_count == 1 { "" } else { "s" }
-    )
-    .ok();
-    writeln!(writer).ok();
-}
-
-/// Show `---MORE---` prompt and wait for user input.
-/// Returns true to continue, false to stop.
-fn show_more_prompt() -> bool {
-    eprint!("---MORE---");
-    let _ = io::stderr().flush();
-
-    // Read a single byte from stdin in raw mode
-    if crossterm::terminal::enable_raw_mode().is_ok() {
-        let mut buf = [0u8; 1];
-        let result = io::stdin().read_exact(&mut buf);
-        let _ = crossterm::terminal::disable_raw_mode();
-        // Clear the ---MORE--- line
-        eprint!("\r          \r");
-        let _ = io::stderr().flush();
-
-        if result.is_ok() {
-            // 'q' or 'Q' to quit, Ctrl-C to quit
-            return buf[0] != b'q' && buf[0] != b'Q' && buf[0] != 3;
-        }
-    }
-    true
-}
-
 /// Format tracing session output matching Python cqlsh style.
 ///
 /// Displays session metadata and a table of trace events sorted by elapsed time.
@@ -321,10 +156,7 @@ pub fn print_trace(trace: &crate::driver::TracingSession, colorizer: &CqlColoriz
         writeln!(writer).ok();
 
         let mut table = Table::new();
-        table.set_content_arrangement(ContentArrangement::Dynamic);
-        if let Some(w) = terminal_width() {
-            table.set_width(w);
-        }
+        table.set_content_arrangement(ContentArrangement::Disabled);
         table.load_preset(CQLSH_PRESET);
         table.set_header(vec![
             Cell::new(colorizer.colorize_header("activity")),
@@ -503,10 +335,7 @@ mod tests {
         let mut buf = Vec::new();
         print_tabular(&result, &no_color(), &mut buf);
         let output = String::from_utf8(buf).unwrap();
-        // Bug: row separators were `||||` instead of proper formatting.
-        // The header separator should use `-` and `+`, not `|`.
         assert!(!output.contains("||||"), "row separators should not contain pipe characters");
-        // Header separator should exist with dashes and plus signs
         assert!(output.contains("-+-") || output.contains("---"), "header separator should use dashes");
     }
 
@@ -516,7 +345,6 @@ mod tests {
         let mut buf = Vec::new();
         print_tabular(&result, &no_color(), &mut buf);
         let output = String::from_utf8(buf).unwrap();
-        // Data rows should have `|` as column separator
         assert!(output.contains("| "), "columns should be separated by pipes");
     }
 
@@ -549,5 +377,35 @@ mod tests {
         assert!(output.contains("SELECT * FROM test"));
         assert!(output.contains("1234 microseconds"));
         assert!(output.contains("Parsing request"));
+    }
+
+    #[test]
+    fn wide_table_not_truncated() {
+        let columns: Vec<CqlColumn> = (0..20)
+            .map(|i| CqlColumn {
+                name: format!("column_{i}"),
+                type_name: "text".to_string(),
+            })
+            .collect();
+        let rows = vec![CqlRow {
+            values: (0..20)
+                .map(|i| CqlValue::Text(format!("value_{i}_with_long_content")))
+                .collect(),
+        }];
+        let result = CqlResult {
+            columns,
+            rows,
+            has_rows: true,
+            tracing_id: None,
+            warnings: vec![],
+        };
+        let mut buf = Vec::new();
+        print_tabular(&result, &no_color(), &mut buf);
+        let output = String::from_utf8(buf).unwrap();
+        // All 20 columns should appear on the header line
+        assert!(output.contains("column_0"));
+        assert!(output.contains("column_19"));
+        // Values should not be truncated
+        assert!(output.contains("value_19_with_long_content"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! cqlsh-rs library — exposes modules for benchmarks and integration tests.
 
 pub mod cli;
+pub mod colorizer;
 pub mod completer;
 pub mod config;
 pub mod describe;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod describe;
 pub mod driver;
 pub mod error;
 pub mod formatter;
+pub mod pager;
 pub mod parser;
 pub mod repl;
 pub mod schema_cache;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! cqlsh-rs library — exposes modules for benchmarks and integration tests.
 
 pub mod cli;
+pub mod completer;
 pub mod config;
 pub mod describe;
 pub mod driver;
@@ -8,5 +9,6 @@ pub mod error;
 pub mod formatter;
 pub mod parser;
 pub mod repl;
+pub mod schema_cache;
 pub mod session;
 pub mod shell_completions;

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -1,0 +1,30 @@
+//! Built-in terminal pager using sapling-streampager.
+//!
+//! Provides a less-like pager with vertical/horizontal scrolling, search,
+//! and proper ANSI color support. Uses termwiz for ANSI-aware rendering,
+//! so horizontal scrolling works correctly with colored output.
+//! Small output that fits the terminal is printed directly (Hybrid mode).
+
+use std::io::Cursor;
+
+use streampager::config::{InterfaceMode, WrappingMode};
+use streampager::Pager;
+
+/// Display content through the streampager pager.
+///
+/// Supports up/down scrolling, left/right horizontal scrolling for wide tables,
+/// `/pattern` search, and correctly handles ANSI color codes.
+/// If the content fits the terminal screen, it is printed directly (Hybrid mode).
+///
+/// An optional `title` is shown at the top of the pager (e.g., column names).
+///
+/// Returns `Err` if the pager fails to start; caller should fall back to direct print.
+pub fn page_content(content: &str, title: &str) -> anyhow::Result<()> {
+    let mut pager = Pager::new_using_system_terminal()?;
+    pager.set_interface_mode(InterfaceMode::Hybrid);
+    pager.set_wrapping_mode(WrappingMode::Unwrapped);
+    pager.set_scroll_past_eof(false);
+    pager.add_stream(Cursor::new(content.to_owned().into_bytes()), title)?;
+    pager.run()?;
+    Ok(())
+}

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -433,6 +433,12 @@ fn dispatch_input<'a>(
         return;
     }
 
+    // Handle LOGIN (stub — implementation deferred to Phase 4)
+    if upper == "LOGIN" || upper.starts_with("LOGIN ") {
+        eprintln!("LOGIN command is not yet implemented. Use --username and --password flags.");
+        return;
+    }
+
     // Handle DESCRIBE / DESC
     if upper == "DESCRIBE" || upper == "DESC" || upper.starts_with("DESCRIBE ") || upper.starts_with("DESC ") {
         let args = if upper.starts_with("DESCRIBE ") {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -78,8 +78,10 @@ fn resolve_history_path(config: &MergedConfig) -> Option<PathBuf> {
 struct ShellState {
     /// Whether expanded (vertical) output is enabled.
     expand: bool,
-    /// Paging configuration: None = disabled, Some(n) = page size.
-    page_size: Option<i32>,
+    /// Whether to pipe output through the built-in pager.
+    paging_enabled: bool,
+    /// Whether stdout is a TTY (controls pager auto-disable).
+    is_tty: bool,
     /// Active CAPTURE file handle (output is tee'd to this file).
     capture_file: Option<File>,
     /// Path of the active capture file (for display).
@@ -94,10 +96,32 @@ struct ShellState {
 
 impl ShellState {
     /// Write output line to both stdout and the capture file (if active).
+    /// Used for short shell command output that doesn't need paging.
     fn outputln(&mut self, text: &str) {
         println!("{text}");
         if let Some(ref mut f) = self.capture_file {
             let _ = writeln!(f, "{text}");
+        }
+    }
+
+    /// Display output, routing through the pager if enabled, and writing to capture file.
+    /// An optional `title` is shown at the top of the pager (e.g., column names).
+    fn display_output(&mut self, content: &[u8], title: &str) {
+        // Write to capture file if active
+        if let Some(ref mut f) = self.capture_file {
+            let _ = f.write_all(content);
+        }
+
+        let text = String::from_utf8_lossy(content);
+
+        // Route through pager or print directly
+        if self.paging_enabled && self.is_tty {
+            if crate::pager::page_content(&text, title).is_err() {
+                // Fallback: print directly if pager fails
+                print!("{text}");
+            }
+        } else {
+            print!("{text}");
         }
     }
 }
@@ -163,10 +187,12 @@ pub async fn run(session: &mut CqlSession, config: &MergedConfig) -> Result<()> 
 
     let username = config.username.as_deref();
     let mut stmt_parser = StatementParser::new();
+    let is_tty = std::io::stdout().is_terminal();
     let colorizer = CqlColorizer::new(color_enabled);
     let mut shell = ShellState {
         expand: false,
-        page_size: Some(100),
+        paging_enabled: true,
+        is_tty,
         capture_file: None,
         capture_path: None,
         schema_cache: Some(Arc::clone(&schema_cache)),
@@ -355,31 +381,27 @@ fn dispatch_input<'a>(
 
     // Handle PAGING
     if upper == "PAGING" {
-        match shell.page_size {
-            Some(size) => shell.outputln(&format!("Page size: {size}")),
-            None => shell.outputln("Paging is currently disabled."),
+        if shell.paging_enabled {
+            shell.outputln("Query paging is currently enabled. Use PAGING OFF to disable.");
+        } else {
+            shell.outputln("Query paging is currently disabled. Use PAGING ON to enable.");
         }
         return;
     }
     if upper == "PAGING ON" {
-        shell.page_size = Some(100);
-        shell.outputln("Page size: 100");
+        shell.paging_enabled = true;
+        shell.outputln("Now query paging is enabled.");
         return;
     }
     if upper == "PAGING OFF" {
-        shell.page_size = None;
+        shell.paging_enabled = false;
         shell.outputln("Disabled paging.");
         return;
     }
-    if let Some(rest) = upper.strip_prefix("PAGING ") {
-        let size_str = rest.trim();
-        match size_str.parse::<i32>() {
-            Ok(size) if size > 0 => {
-                shell.page_size = Some(size);
-                shell.outputln(&format!("Page size: {size}"));
-            }
-            _ => eprintln!("Invalid page size: {}", rest.trim()),
-        }
+    if upper.strip_prefix("PAGING ").is_some() {
+        // Accept PAGING <N> for compatibility — enables paging
+        shell.paging_enabled = true;
+        shell.outputln("Now query paging is enabled.");
         return;
     }
 
@@ -451,9 +473,9 @@ fn dispatch_input<'a>(
         } else {
             ""
         };
-        let mut writer = TeeWriter { capture: shell.capture_file.as_mut() };
-        match describe::execute(session, args, &mut writer).await {
-            Ok(()) => {}
+        let mut buf = Vec::new();
+        match describe::execute(session, args, &mut buf).await {
+            Ok(()) => shell.display_output(&buf, ""),
             Err(e) => eprintln!("Error: {e}"),
         }
         return;
@@ -478,9 +500,9 @@ fn dispatch_input<'a>(
             Ok(trace_id) => {
                 match session.get_trace_session(trace_id).await {
                     Ok(Some(trace)) => {
-                        let colorizer = &shell.colorizer;
-                        let mut writer = TeeWriter { capture: shell.capture_file.as_mut() };
-                        formatter::print_trace(&trace, colorizer, &mut writer);
+                        let mut buf = Vec::new();
+                        formatter::print_trace(&trace, &shell.colorizer, &mut buf);
+                        shell.display_output(&buf, "");
                     }
                     Ok(None) => eprintln!("Trace session {trace_id} not found."),
                     Err(e) => eprintln!("Error fetching trace: {e}"),
@@ -524,17 +546,21 @@ fn dispatch_input<'a>(
             }
 
             if !result.columns.is_empty() {
-                let expand = shell.expand;
-                let page_size = shell.page_size;
-                let colorizer = &shell.colorizer;
-                let mut writer = TeeWriter { capture: shell.capture_file.as_mut() };
-                if let Some(ps) = page_size {
-                    formatter::print_paged(&result, ps as usize, expand, colorizer, &mut writer);
-                } else if expand {
-                    formatter::print_expanded(&result, colorizer, &mut writer);
+                // Build column list for pager title (sticky header context)
+                let col_title = result
+                    .columns
+                    .iter()
+                    .map(|c| c.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(" | ");
+
+                let mut buf = Vec::new();
+                if shell.expand {
+                    formatter::print_expanded(&result, &shell.colorizer, &mut buf);
                 } else {
-                    formatter::print_tabular(&result, colorizer, &mut writer);
+                    formatter::print_tabular(&result, &shell.colorizer, &mut buf);
                 }
+                shell.display_output(&buf, &col_title);
             }
 
             // Print trace info if tracing is enabled
@@ -544,9 +570,9 @@ fn dispatch_input<'a>(
                     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                     match session.get_trace_session(trace_id).await {
                         Ok(Some(trace)) => {
-                            let colorizer = &shell.colorizer;
-                            let mut writer = TeeWriter { capture: shell.capture_file.as_mut() };
-                            formatter::print_trace(&trace, colorizer, &mut writer);
+                            let mut buf = Vec::new();
+                            formatter::print_trace(&trace, &shell.colorizer, &mut buf);
+                            shell.display_output(&buf, "");
                         }
                         Ok(None) => {
                             shell.outputln(&format!(
@@ -702,29 +728,6 @@ fn execute_source<'a>(
     })
 }
 
-/// Writer that tees output to both stdout and an optional capture file.
-struct TeeWriter<'a> {
-    capture: Option<&'a mut File>,
-}
-
-impl<'a> Write for TeeWriter<'a> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let n = io::stdout().write(buf)?;
-        if let Some(ref mut capture) = self.capture {
-            let _ = capture.write_all(&buf[..n]);
-        }
-        Ok(n)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        io::stdout().flush()?;
-        if let Some(ref mut capture) = self.capture {
-            let _ = capture.flush();
-        }
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -792,7 +795,8 @@ mod tests {
     fn shell_state_initial() {
         let state = ShellState {
             expand: false,
-            page_size: Some(100),
+            paging_enabled: true,
+            is_tty: false,
             capture_file: None,
             capture_path: None,
             schema_cache: None,
@@ -800,7 +804,7 @@ mod tests {
             colorizer: CqlColorizer::new(false),
         };
         assert!(!state.expand);
-        assert_eq!(state.page_size, Some(100));
+        assert!(state.paging_enabled);
         assert!(state.capture_file.is_none());
         assert!(state.capture_path.is_none());
     }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -15,6 +15,7 @@ use rustyline::history::DefaultHistory;
 use rustyline::{CompletionType, Config, EditMode, Editor};
 use tokio::sync::RwLock;
 
+use crate::colorizer::CqlColorizer;
 use crate::completer::CqlCompleter;
 use crate::config::MergedConfig;
 use crate::describe;
@@ -87,19 +88,8 @@ struct ShellState {
     schema_cache: Option<Arc<RwLock<SchemaCache>>>,
     /// Shared current keyspace for tab completion.
     shared_keyspace: Option<Arc<RwLock<Option<String>>>>,
-}
-
-impl Default for ShellState {
-    fn default() -> Self {
-        Self {
-            expand: false,
-            page_size: Some(100),
-            capture_file: None,
-            capture_path: None,
-            schema_cache: None,
-            shared_keyspace: None,
-        }
-    }
+    /// Output colorizer for result values, headers, and errors.
+    colorizer: CqlColorizer,
 }
 
 impl ShellState {
@@ -173,10 +163,15 @@ pub async fn run(session: &mut CqlSession, config: &MergedConfig) -> Result<()> 
 
     let username = config.username.as_deref();
     let mut stmt_parser = StatementParser::new();
+    let colorizer = CqlColorizer::new(color_enabled);
     let mut shell = ShellState {
+        expand: false,
+        page_size: Some(100),
+        capture_file: None,
+        capture_path: None,
         schema_cache: Some(Arc::clone(&schema_cache)),
         shared_keyspace: Some(Arc::clone(&current_keyspace)),
-        ..ShellState::default()
+        colorizer,
     };
 
     loop {
@@ -483,8 +478,9 @@ fn dispatch_input<'a>(
             Ok(trace_id) => {
                 match session.get_trace_session(trace_id).await {
                     Ok(Some(trace)) => {
+                        let colorizer = &shell.colorizer;
                         let mut writer = TeeWriter { capture: shell.capture_file.as_mut() };
-                        formatter::print_trace(&trace, &mut writer);
+                        formatter::print_trace(&trace, colorizer, &mut writer);
                     }
                     Ok(None) => eprintln!("Trace session {trace_id} not found."),
                     Err(e) => eprintln!("Error fetching trace: {e}"),
@@ -521,21 +517,23 @@ fn dispatch_input<'a>(
                 }
             }
 
-            // Print warnings if present
+            // Print warnings if present (red bold when colored)
             for warning in &result.warnings {
-                shell.outputln(&format!("Warnings: {warning}"));
+                let msg = format!("Warnings: {warning}");
+                eprintln!("{}", shell.colorizer.colorize_warning(&msg));
             }
 
             if !result.columns.is_empty() {
                 let expand = shell.expand;
                 let page_size = shell.page_size;
+                let colorizer = &shell.colorizer;
                 let mut writer = TeeWriter { capture: shell.capture_file.as_mut() };
                 if let Some(ps) = page_size {
-                    formatter::print_paged(&result, ps as usize, expand, &mut writer);
+                    formatter::print_paged(&result, ps as usize, expand, colorizer, &mut writer);
                 } else if expand {
-                    formatter::print_expanded(&result, &mut writer);
+                    formatter::print_expanded(&result, colorizer, &mut writer);
                 } else {
-                    formatter::print_tabular(&result, &mut writer);
+                    formatter::print_tabular(&result, colorizer, &mut writer);
                 }
             }
 
@@ -546,8 +544,9 @@ fn dispatch_input<'a>(
                     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                     match session.get_trace_session(trace_id).await {
                         Ok(Some(trace)) => {
+                            let colorizer = &shell.colorizer;
                             let mut writer = TeeWriter { capture: shell.capture_file.as_mut() };
-                            formatter::print_trace(&trace, &mut writer);
+                            formatter::print_trace(&trace, colorizer, &mut writer);
                         }
                         Ok(None) => {
                             shell.outputln(&format!(
@@ -562,7 +561,7 @@ fn dispatch_input<'a>(
             }
         }
         Err(e) => {
-            eprintln!("{}", error::format_error(&e));
+            eprintln!("{}", error::format_error_colored(&e, &shell.colorizer));
             if config.debug {
                 eprintln!("Debug: {e:?}");
             }
@@ -790,8 +789,16 @@ mod tests {
     }
 
     #[test]
-    fn shell_state_default() {
-        let state = ShellState::default();
+    fn shell_state_initial() {
+        let state = ShellState {
+            expand: false,
+            page_size: Some(100),
+            capture_file: None,
+            capture_path: None,
+            schema_cache: None,
+            shared_keyspace: None,
+            colorizer: CqlColorizer::new(false),
+        };
         assert!(!state.expand);
         assert_eq!(state.page_size, Some(100));
         assert!(state.capture_file.is_none());

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -5,7 +5,7 @@
 //! prompt formatting, and Ctrl-C/Ctrl-D handling.
 
 use std::fs::File;
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, IsTerminal, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -143,10 +143,18 @@ pub async fn run(session: &mut CqlSession, config: &MergedConfig) -> Result<()> 
         }
     }
 
+    // Resolve color mode: Auto → check if stdout is a terminal
+    let color_enabled = match config.color {
+        crate::config::ColorMode::On => true,
+        crate::config::ColorMode::Off => false,
+        crate::config::ColorMode::Auto => std::io::stdout().is_terminal(),
+    };
+
     let completer = CqlCompleter::new(
         Arc::clone(&schema_cache),
         Arc::clone(&current_keyspace),
         tokio::runtime::Handle::current(),
+        color_enabled,
     );
 
     let mut rl: Editor<CqlCompleter, DefaultHistory> =

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -426,6 +426,29 @@ fn dispatch_input<'a>(
         return;
     }
 
+    // Handle SHOW SESSION <uuid>
+    if let Some(rest) = upper.strip_prefix("SHOW SESSION ") {
+        let uuid_str = rest.trim();
+        match uuid::Uuid::parse_str(uuid_str) {
+            Ok(trace_id) => {
+                match session.get_trace_session(trace_id).await {
+                    Ok(Some(trace)) => {
+                        let mut writer = TeeWriter { capture: shell.capture_file.as_mut() };
+                        formatter::print_trace(&trace, &mut writer);
+                    }
+                    Ok(None) => eprintln!("Trace session {trace_id} not found."),
+                    Err(e) => eprintln!("Error fetching trace: {e}"),
+                }
+            }
+            Err(_) => eprintln!("Invalid UUID: {uuid_str}"),
+        }
+        return;
+    }
+    if upper == "SHOW SESSION" {
+        eprintln!("Usage: SHOW SESSION <trace-uuid>");
+        return;
+    }
+
     // Execute as CQL statement
     match session.execute(trimmed).await {
         Ok(result) => {
@@ -493,7 +516,7 @@ Documented shell commands:
   HELP          Show this help or help on a topic
   PAGING        Configure automatic paging
   SERIAL        Get/set serial consistency level
-  SHOW          Show version or host info
+  SHOW          Show version, host, or session trace info
   SOURCE        Execute CQL from a file
   TRACING       Toggle request tracing
 
@@ -759,6 +782,32 @@ mod tests {
     }
 
     // --- BUG: Shell commands with trailing semicolons ---
+
+    // --- SHOW SESSION tests ---
+
+    #[test]
+    fn show_session_parses_uuid() {
+        let input = "SHOW SESSION 12345678-1234-1234-1234-123456789abc";
+        let upper = input.trim().to_uppercase();
+        assert!(upper.starts_with("SHOW SESSION "));
+        let uuid_str = input.trim()["SHOW SESSION ".len()..].trim();
+        let uuid = uuid::Uuid::parse_str(uuid_str).unwrap();
+        assert_eq!(uuid.to_string(), "12345678-1234-1234-1234-123456789abc");
+    }
+
+    #[test]
+    fn show_session_rejects_invalid_uuid() {
+        let uuid_str = "not-a-uuid";
+        assert!(uuid::Uuid::parse_str(uuid_str).is_err());
+    }
+
+    #[test]
+    fn show_session_bare_detected_as_shell_command() {
+        assert!(parser::is_shell_command("SHOW SESSION 12345678-1234-1234-1234-123456789abc"));
+        assert!(parser::is_shell_command("SHOW SESSION"));
+    }
+
+    // --- Shell command semicolon tests ---
 
     #[test]
     fn shell_command_semicolon_stripped_before_dispatch() {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -7,17 +7,21 @@
 use std::fs::File;
 use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use anyhow::Result;
 use rustyline::error::ReadlineError;
 use rustyline::history::DefaultHistory;
-use rustyline::{Config, EditMode, Editor};
+use rustyline::{CompletionType, Config, EditMode, Editor};
+use tokio::sync::RwLock;
 
+use crate::completer::CqlCompleter;
 use crate::config::MergedConfig;
 use crate::describe;
 use crate::error;
 use crate::formatter;
 use crate::parser::{self, ParseResult, StatementParser};
+use crate::schema_cache::SchemaCache;
 use crate::session::CqlSession;
 
 /// Default history file path: ~/.cassandra/cql_history
@@ -79,6 +83,10 @@ struct ShellState {
     capture_file: Option<File>,
     /// Path of the active capture file (for display).
     capture_path: Option<PathBuf>,
+    /// Shared schema cache for tab completion (invalidated on DDL).
+    schema_cache: Option<Arc<RwLock<SchemaCache>>>,
+    /// Shared current keyspace for tab completion.
+    shared_keyspace: Option<Arc<RwLock<Option<String>>>>,
 }
 
 impl Default for ShellState {
@@ -88,6 +96,8 @@ impl Default for ShellState {
             page_size: Some(100),
             capture_file: None,
             capture_path: None,
+            schema_cache: None,
+            shared_keyspace: None,
         }
     }
 }
@@ -117,9 +127,31 @@ pub async fn run(session: &mut CqlSession, config: &MergedConfig) -> Result<()> 
         .expect("valid history size")
         .edit_mode(EditMode::Emacs)
         .auto_add_history(true)
+        .completion_type(CompletionType::List)
         .build();
 
-    let mut rl: Editor<(), DefaultHistory> = Editor::with_config(rl_config)?;
+    // Set up schema cache and tab completer
+    let schema_cache = Arc::new(RwLock::new(SchemaCache::new()));
+    let current_keyspace: Arc<RwLock<Option<String>>> =
+        Arc::new(RwLock::new(session.current_keyspace().map(String::from)));
+
+    // Initial schema cache population (best-effort)
+    {
+        let mut cache = schema_cache.write().await;
+        if let Err(e) = cache.refresh(session).await {
+            eprintln!("Warning: could not load schema for tab completion: {e}");
+        }
+    }
+
+    let completer = CqlCompleter::new(
+        Arc::clone(&schema_cache),
+        Arc::clone(&current_keyspace),
+        tokio::runtime::Handle::current(),
+    );
+
+    let mut rl: Editor<CqlCompleter, DefaultHistory> =
+        Editor::with_config(rl_config)?;
+    rl.set_helper(Some(completer));
 
     // Load history
     let history_path = resolve_history_path(config);
@@ -133,7 +165,11 @@ pub async fn run(session: &mut CqlSession, config: &MergedConfig) -> Result<()> 
 
     let username = config.username.as_deref();
     let mut stmt_parser = StatementParser::new();
-    let mut shell = ShellState::default();
+    let mut shell = ShellState {
+        schema_cache: Some(Arc::clone(&schema_cache)),
+        shared_keyspace: Some(Arc::clone(&current_keyspace)),
+        ..ShellState::default()
+    };
 
     loop {
         let prompt = if stmt_parser.is_empty() {
@@ -452,6 +488,25 @@ fn dispatch_input<'a>(
     // Execute as CQL statement
     match session.execute(trimmed).await {
         Ok(result) => {
+            // Sync current keyspace for tab completion after USE
+            let upper_stmt = trimmed.to_uppercase();
+            if upper_stmt.starts_with("USE ") {
+                if let Some(ref shared_ks) = shell.shared_keyspace {
+                    let ks = session.current_keyspace().map(String::from);
+                    let shared = Arc::clone(shared_ks);
+                    *shared.blocking_write() = ks;
+                }
+            }
+
+            // Invalidate schema cache after DDL statements
+            if upper_stmt.starts_with("CREATE ") || upper_stmt.starts_with("ALTER ") || upper_stmt.starts_with("DROP ") {
+                if let Some(ref cache) = shell.schema_cache {
+                    if let Ok(mut c) = cache.try_write() {
+                        c.invalidate();
+                    }
+                }
+            }
+
             // Print warnings if present
             for warning in &result.warnings {
                 shell.outputln(&format!("Warnings: {warning}"));

--- a/src/schema_cache.rs
+++ b/src/schema_cache.rs
@@ -1,0 +1,542 @@
+//! Schema metadata cache for tab completion.
+//!
+//! Provides a `SchemaCache` struct that caches CQL schema metadata (keyspaces,
+//! tables, columns, UDTs, functions, aggregates) fetched from the database.
+//! The cache supports TTL-based staleness checks so it refreshes periodically.
+//!
+//! The REPL wraps `SchemaCache` in an `Arc<RwLock<>>` for shared async access.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+
+use crate::driver::{
+    AggregateMetadata, FunctionMetadata, KeyspaceMetadata, TableMetadata, UdtMetadata,
+};
+use crate::session::CqlSession;
+
+/// Default TTL for cached schema data (30 seconds).
+const DEFAULT_TTL: Duration = Duration::from_secs(30);
+
+/// Cached schema metadata for a CQL cluster.
+///
+/// Stores keyspaces, tables, UDTs, functions, and aggregates fetched from the
+/// cluster. Lookup methods are synchronous — callers must call `refresh()` to
+/// populate or update the cache.
+pub struct SchemaCache {
+    /// All keyspaces in the cluster.
+    keyspaces: Vec<KeyspaceMetadata>,
+    /// Tables indexed by keyspace name.
+    tables: HashMap<String, Vec<TableMetadata>>,
+    /// UDTs indexed by keyspace name.
+    udts: HashMap<String, Vec<UdtMetadata>>,
+    /// Functions indexed by keyspace name.
+    functions: HashMap<String, Vec<FunctionMetadata>>,
+    /// Aggregates indexed by keyspace name.
+    aggregates: HashMap<String, Vec<AggregateMetadata>>,
+    /// When the cache was last successfully refreshed.
+    last_refresh: Option<Instant>,
+    /// How long before the cache is considered stale.
+    ttl: Duration,
+}
+
+impl SchemaCache {
+    /// Create a new, empty cache with the default TTL of 30 seconds.
+    pub fn new() -> Self {
+        Self::with_ttl(DEFAULT_TTL)
+    }
+
+    /// Create a new, empty cache with a custom TTL.
+    pub fn with_ttl(ttl: Duration) -> Self {
+        SchemaCache {
+            keyspaces: Vec::new(),
+            tables: HashMap::new(),
+            udts: HashMap::new(),
+            functions: HashMap::new(),
+            aggregates: HashMap::new(),
+            last_refresh: None,
+            ttl,
+        }
+    }
+
+    /// Returns `true` if the cache has never been refreshed or its TTL has elapsed.
+    pub fn is_stale(&self) -> bool {
+        match self.last_refresh {
+            None => true,
+            Some(refreshed_at) => refreshed_at.elapsed() >= self.ttl,
+        }
+    }
+
+    /// Force the cache to appear stale so the next access triggers a refresh.
+    pub fn invalidate(&mut self) {
+        self.last_refresh = None;
+    }
+
+    /// Refresh the cache by fetching all schema metadata from the cluster.
+    ///
+    /// Fetches all keyspaces first, then tables, UDTs, functions, and
+    /// aggregates for each keyspace in parallel (sequentially per keyspace for
+    /// simplicity — a future optimisation could use `join_all`).
+    pub async fn refresh(&mut self, session: &CqlSession) -> Result<()> {
+        let keyspaces = session.get_keyspaces().await?;
+
+        let mut tables: HashMap<String, Vec<TableMetadata>> = HashMap::new();
+        let mut udts: HashMap<String, Vec<UdtMetadata>> = HashMap::new();
+        let mut functions: HashMap<String, Vec<FunctionMetadata>> = HashMap::new();
+        let mut aggregates: HashMap<String, Vec<AggregateMetadata>> = HashMap::new();
+
+        for ks in &keyspaces {
+            let ks_name = ks.name.as_str();
+
+            // Ignore errors for individual keyspaces — best-effort population.
+            if let Ok(t) = session.get_tables(ks_name).await {
+                tables.insert(ks_name.to_string(), t);
+            }
+            if let Ok(u) = session.get_udts(ks_name).await {
+                udts.insert(ks_name.to_string(), u);
+            }
+            if let Ok(f) = session.get_functions(ks_name).await {
+                functions.insert(ks_name.to_string(), f);
+            }
+            if let Ok(a) = session.get_aggregates(ks_name).await {
+                aggregates.insert(ks_name.to_string(), a);
+            }
+        }
+
+        self.keyspaces = keyspaces;
+        self.tables = tables;
+        self.udts = udts;
+        self.functions = functions;
+        self.aggregates = aggregates;
+        self.last_refresh = Some(Instant::now());
+
+        Ok(())
+    }
+
+    // ── Lookup helpers ────────────────────────────────────────────────────────
+
+    /// Return the names of all cached keyspaces.
+    pub fn keyspace_names(&self) -> Vec<&str> {
+        self.keyspaces.iter().map(|ks| ks.name.as_str()).collect()
+    }
+
+    /// Return the names of all tables in `keyspace`.
+    ///
+    /// Returns an empty `Vec` if the keyspace is unknown.
+    pub fn table_names(&self, keyspace: &str) -> Vec<&str> {
+        self.tables
+            .get(keyspace)
+            .map(|tables| tables.iter().map(|t| t.name.as_str()).collect())
+            .unwrap_or_default()
+    }
+
+    /// Return the names of all columns in `keyspace.table`.
+    ///
+    /// Returns an empty `Vec` if the keyspace or table is unknown.
+    pub fn column_names(&self, keyspace: &str, table: &str) -> Vec<&str> {
+        self.tables
+            .get(keyspace)
+            .and_then(|tables| tables.iter().find(|t| t.name == table))
+            .map(|t| t.columns.iter().map(|c| c.name.as_str()).collect())
+            .unwrap_or_default()
+    }
+
+    /// Return the names of all UDTs in `keyspace`.
+    ///
+    /// Returns an empty `Vec` if the keyspace is unknown.
+    pub fn udt_names(&self, keyspace: &str) -> Vec<&str> {
+        self.udts
+            .get(keyspace)
+            .map(|udts| udts.iter().map(|u| u.name.as_str()).collect())
+            .unwrap_or_default()
+    }
+
+    /// Return the names of all functions in `keyspace`.
+    ///
+    /// Returns an empty `Vec` if the keyspace is unknown.
+    pub fn function_names(&self, keyspace: &str) -> Vec<&str> {
+        self.functions
+            .get(keyspace)
+            .map(|fns| fns.iter().map(|f| f.name.as_str()).collect())
+            .unwrap_or_default()
+    }
+
+    /// Return the names of all aggregates in `keyspace`.
+    ///
+    /// Returns an empty `Vec` if the keyspace is unknown.
+    pub fn aggregate_names(&self, keyspace: &str) -> Vec<&str> {
+        self.aggregates
+            .get(keyspace)
+            .map(|aggs| aggs.iter().map(|a| a.name.as_str()).collect())
+            .unwrap_or_default()
+    }
+}
+
+impl Default for SchemaCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::{ColumnMetadata, KeyspaceMetadata, TableMetadata, UdtMetadata};
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn make_keyspace(name: &str) -> KeyspaceMetadata {
+        KeyspaceMetadata {
+            name: name.to_string(),
+            replication: HashMap::new(),
+            durable_writes: true,
+        }
+    }
+
+    fn make_table(keyspace: &str, name: &str, columns: &[(&str, &str)]) -> TableMetadata {
+        TableMetadata {
+            keyspace: keyspace.to_string(),
+            name: name.to_string(),
+            columns: columns
+                .iter()
+                .map(|(col_name, col_type)| ColumnMetadata {
+                    name: col_name.to_string(),
+                    type_name: col_type.to_string(),
+                })
+                .collect(),
+            partition_key: vec![],
+            clustering_key: vec![],
+        }
+    }
+
+    fn make_udt(keyspace: &str, name: &str) -> UdtMetadata {
+        UdtMetadata {
+            keyspace: keyspace.to_string(),
+            name: name.to_string(),
+            field_names: vec!["street".to_string()],
+            field_types: vec!["text".to_string()],
+        }
+    }
+
+    fn make_function(keyspace: &str, name: &str) -> FunctionMetadata {
+        FunctionMetadata {
+            keyspace: keyspace.to_string(),
+            name: name.to_string(),
+            argument_types: vec![],
+            return_type: "text".to_string(),
+        }
+    }
+
+    fn make_aggregate(keyspace: &str, name: &str) -> AggregateMetadata {
+        AggregateMetadata {
+            keyspace: keyspace.to_string(),
+            name: name.to_string(),
+            argument_types: vec![],
+            return_type: "int".to_string(),
+        }
+    }
+
+    /// Build a pre-populated `SchemaCache` without going through `refresh()`.
+    fn populated_cache() -> SchemaCache {
+        let mut cache = SchemaCache::new();
+
+        cache.keyspaces = vec![make_keyspace("ks1"), make_keyspace("ks2")];
+
+        cache.tables.insert(
+            "ks1".to_string(),
+            vec![
+                make_table("ks1", "users", &[("id", "uuid"), ("name", "text")]),
+                make_table("ks1", "orders", &[("order_id", "uuid"), ("total", "decimal")]),
+            ],
+        );
+        cache.tables.insert(
+            "ks2".to_string(),
+            vec![make_table("ks2", "events", &[("event_id", "uuid")])],
+        );
+
+        cache
+            .udts
+            .insert("ks1".to_string(), vec![make_udt("ks1", "address")]);
+
+        cache
+            .functions
+            .insert("ks1".to_string(), vec![make_function("ks1", "my_func")]);
+
+        cache
+            .aggregates
+            .insert("ks1".to_string(), vec![make_aggregate("ks1", "my_agg")]);
+
+        // Mark as freshly refreshed so staleness tests work correctly.
+        cache.last_refresh = Some(Instant::now());
+
+        cache
+    }
+
+    // ── Constructor tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn new_cache_is_empty_and_stale() {
+        let cache = SchemaCache::new();
+        assert!(cache.is_stale(), "fresh cache should be stale (never refreshed)");
+        assert!(cache.keyspace_names().is_empty());
+    }
+
+    #[test]
+    fn default_ttl_is_thirty_seconds() {
+        let cache = SchemaCache::new();
+        assert_eq!(cache.ttl, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn with_ttl_stores_custom_ttl() {
+        let cache = SchemaCache::with_ttl(Duration::from_secs(60));
+        assert_eq!(cache.ttl, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn default_impl_equals_new() {
+        let a = SchemaCache::new();
+        let b = SchemaCache::default();
+        assert_eq!(a.ttl, b.ttl);
+        assert!(a.keyspace_names().is_empty());
+        assert!(b.keyspace_names().is_empty());
+    }
+
+    // ── Staleness / TTL tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn freshly_refreshed_cache_is_not_stale() {
+        let cache = populated_cache();
+        assert!(!cache.is_stale());
+    }
+
+    #[test]
+    fn expired_cache_is_stale() {
+        let mut cache = SchemaCache::with_ttl(Duration::from_millis(1));
+        // Simulate a refresh that happened long enough ago.
+        cache.last_refresh = Some(Instant::now() - Duration::from_millis(10));
+        assert!(cache.is_stale());
+    }
+
+    #[test]
+    fn invalidate_marks_cache_stale() {
+        let mut cache = populated_cache();
+        assert!(!cache.is_stale());
+        cache.invalidate();
+        assert!(cache.is_stale());
+    }
+
+    #[test]
+    fn invalidate_preserves_cached_data() {
+        let mut cache = populated_cache();
+        cache.invalidate();
+        // Data is still present even though the cache is stale.
+        assert!(!cache.keyspace_names().is_empty());
+        assert!(!cache.table_names("ks1").is_empty());
+    }
+
+    // ── keyspace_names tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn keyspace_names_returns_all_keyspaces() {
+        let cache = populated_cache();
+        let mut names = cache.keyspace_names();
+        names.sort();
+        assert_eq!(names, vec!["ks1", "ks2"]);
+    }
+
+    #[test]
+    fn keyspace_names_empty_when_no_data() {
+        let cache = SchemaCache::new();
+        assert!(cache.keyspace_names().is_empty());
+    }
+
+    // ── table_names tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn table_names_returns_tables_for_keyspace() {
+        let cache = populated_cache();
+        let mut tables = cache.table_names("ks1");
+        tables.sort();
+        assert_eq!(tables, vec!["orders", "users"]);
+    }
+
+    #[test]
+    fn table_names_empty_for_unknown_keyspace() {
+        let cache = populated_cache();
+        assert!(cache.table_names("nonexistent").is_empty());
+    }
+
+    #[test]
+    fn table_names_single_table_keyspace() {
+        let cache = populated_cache();
+        assert_eq!(cache.table_names("ks2"), vec!["events"]);
+    }
+
+    // ── column_names tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn column_names_returns_columns_for_table() {
+        let cache = populated_cache();
+        let mut cols = cache.column_names("ks1", "users");
+        cols.sort();
+        assert_eq!(cols, vec!["id", "name"]);
+    }
+
+    #[test]
+    fn column_names_empty_for_unknown_table() {
+        let cache = populated_cache();
+        assert!(cache.column_names("ks1", "nonexistent").is_empty());
+    }
+
+    #[test]
+    fn column_names_empty_for_unknown_keyspace() {
+        let cache = populated_cache();
+        assert!(cache.column_names("nonexistent", "users").is_empty());
+    }
+
+    #[test]
+    fn column_names_orders_table() {
+        let cache = populated_cache();
+        let mut cols = cache.column_names("ks1", "orders");
+        cols.sort();
+        assert_eq!(cols, vec!["order_id", "total"]);
+    }
+
+    // ── udt_names tests ───────────────────────────────────────────────────────
+
+    #[test]
+    fn udt_names_returns_udts_for_keyspace() {
+        let cache = populated_cache();
+        assert_eq!(cache.udt_names("ks1"), vec!["address"]);
+    }
+
+    #[test]
+    fn udt_names_empty_for_keyspace_with_no_udts() {
+        let cache = populated_cache();
+        assert!(cache.udt_names("ks2").is_empty());
+    }
+
+    #[test]
+    fn udt_names_empty_for_unknown_keyspace() {
+        let cache = populated_cache();
+        assert!(cache.udt_names("nonexistent").is_empty());
+    }
+
+    // ── function_names tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn function_names_returns_functions_for_keyspace() {
+        let cache = populated_cache();
+        assert_eq!(cache.function_names("ks1"), vec!["my_func"]);
+    }
+
+    #[test]
+    fn function_names_empty_for_keyspace_with_no_functions() {
+        let cache = populated_cache();
+        assert!(cache.function_names("ks2").is_empty());
+    }
+
+    #[test]
+    fn function_names_empty_for_unknown_keyspace() {
+        let cache = populated_cache();
+        assert!(cache.function_names("nonexistent").is_empty());
+    }
+
+    // ── aggregate_names tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn aggregate_names_returns_aggregates_for_keyspace() {
+        let cache = populated_cache();
+        assert_eq!(cache.aggregate_names("ks1"), vec!["my_agg"]);
+    }
+
+    #[test]
+    fn aggregate_names_empty_for_keyspace_with_no_aggregates() {
+        let cache = populated_cache();
+        assert!(cache.aggregate_names("ks2").is_empty());
+    }
+
+    #[test]
+    fn aggregate_names_empty_for_unknown_keyspace() {
+        let cache = populated_cache();
+        assert!(cache.aggregate_names("nonexistent").is_empty());
+    }
+
+    // ── Multi-keyspace isolation tests ────────────────────────────────────────
+
+    #[test]
+    fn tables_are_isolated_per_keyspace() {
+        let cache = populated_cache();
+        assert!(!cache.table_names("ks1").contains(&"events"));
+        assert!(!cache.table_names("ks2").contains(&"users"));
+    }
+
+    #[test]
+    fn udts_are_isolated_per_keyspace() {
+        let mut cache = populated_cache();
+        cache
+            .udts
+            .insert("ks2".to_string(), vec![make_udt("ks2", "location")]);
+
+        assert_eq!(cache.udt_names("ks1"), vec!["address"]);
+        assert_eq!(cache.udt_names("ks2"), vec!["location"]);
+    }
+
+    // ── Edge-case tests ───────────────────────────────────────────────────────
+
+    #[test]
+    fn multiple_functions_returned_in_order() {
+        let mut cache = SchemaCache::new();
+        cache.keyspaces = vec![make_keyspace("ks1")];
+        cache.functions.insert(
+            "ks1".to_string(),
+            vec![
+                make_function("ks1", "alpha"),
+                make_function("ks1", "beta"),
+                make_function("ks1", "gamma"),
+            ],
+        );
+        cache.last_refresh = Some(Instant::now());
+
+        assert_eq!(cache.function_names("ks1"), vec!["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
+    fn multiple_aggregates_returned_in_order() {
+        let mut cache = SchemaCache::new();
+        cache.keyspaces = vec![make_keyspace("ks1")];
+        cache.aggregates.insert(
+            "ks1".to_string(),
+            vec![
+                make_aggregate("ks1", "agg_a"),
+                make_aggregate("ks1", "agg_b"),
+            ],
+        );
+        cache.last_refresh = Some(Instant::now());
+
+        assert_eq!(cache.aggregate_names("ks1"), vec!["agg_a", "agg_b"]);
+    }
+
+    #[test]
+    fn table_with_no_columns_returns_empty_column_list() {
+        let mut cache = SchemaCache::new();
+        cache.keyspaces = vec![make_keyspace("ks1")];
+        cache.tables.insert(
+            "ks1".to_string(),
+            vec![make_table("ks1", "empty_table", &[])],
+        );
+        cache.last_refresh = Some(Instant::now());
+
+        assert!(cache.column_names("ks1", "empty_table").is_empty());
+    }
+
+    #[test]
+    fn zero_ttl_cache_is_immediately_stale_after_refresh() {
+        let mut cache = SchemaCache::with_ttl(Duration::ZERO);
+        // Simulate a past refresh.
+        cache.last_refresh = Some(Instant::now() - Duration::from_nanos(1));
+        assert!(cache.is_stale());
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -8,8 +8,9 @@ use anyhow::{bail, Result};
 
 use crate::config::MergedConfig;
 use crate::driver::{
-    ConnectionConfig, Consistency, CqlDriver, CqlResult, KeyspaceMetadata, PreparedId,
-    ScyllaDriver, SslConfig, TableMetadata, TracingSession,
+    AggregateMetadata, ConnectionConfig, Consistency, CqlDriver, CqlResult, FunctionMetadata,
+    KeyspaceMetadata, PreparedId, ScyllaDriver, SslConfig, TableMetadata, TracingSession,
+    UdtMetadata,
 };
 
 /// High-level CQL session managing driver state and user preferences.
@@ -213,6 +214,21 @@ impl CqlSession {
         table: &str,
     ) -> Result<Option<TableMetadata>> {
         self.driver.get_table_metadata(keyspace, table).await
+    }
+
+    /// Get metadata for all user-defined types in a keyspace.
+    pub async fn get_udts(&self, keyspace: &str) -> Result<Vec<UdtMetadata>> {
+        self.driver.get_udts(keyspace).await
+    }
+
+    /// Get metadata for all user-defined functions in a keyspace.
+    pub async fn get_functions(&self, keyspace: &str) -> Result<Vec<FunctionMetadata>> {
+        self.driver.get_functions(keyspace).await
+    }
+
+    /// Get metadata for all user-defined aggregates in a keyspace.
+    pub async fn get_aggregates(&self, keyspace: &str) -> Result<Vec<AggregateMetadata>> {
+        self.driver.get_aggregates(keyspace).await
     }
 
     /// Check if the connection is still alive.


### PR DESCRIPTION
## Summary

- **Tab completion**: Context-aware CQL completions (keywords, tables, keyspaces, columns, consistency levels, DESCRIBE targets, file paths) with SchemaCache and DDL-triggered invalidation
- **Syntax highlighting**: Real-time CQL input colorization (keywords blue, strings green, numbers cyan, comments grey)
- **Output coloring**: Python cqlsh-compatible result coloring — values by CQL type (text=yellow, numbers=green, blob=dark magenta, null=red), headers magenta, errors/warnings red, collection delimiters blue
- **Shell commands**: SOURCE, EXPAND, PAGING, CAPTURE, SHOW SESSION, DESCRIBE, LOGIN stub
- **Error handling**: Classified error display matching Python cqlsh error names
- **Parser**: Context-aware CQL statement parser (SP4) with multi-line support

## Test plan

- [x] 300 unit tests pass (`cargo test --lib`)
- [x] Manual verification: colored output matches Python cqlsh for SELECT results
- [x] Manual verification: error messages display in red
- [x] Manual verification: tab completion works for keywords and table names
- [x] Verify `--no-color` flag disables all output coloring
- [ ] Verify piped output has no ANSI codes (`cqlsh -e "SELECT 1" | cat`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)