### PR TITLE
docs(progress): fix stale progress tracking and integrate into dev workflow

### DIFF
--- a/.github/skills/conventional-commit/SKILL.md
+++ b/.github/skills/conventional-commit/SKILL.md
@@ -64,7 +64,12 @@ Use these project-specific scopes:
 | `types` | CQL type system |
 | `auth` | Authentication and SSL/TLS |
 | `plan` | Design documents and plans |
+| `progress` | Progress tracking (`docs/progress.json`) |
 | `skills` | AI assistant skills |
+
+### Progress Tracking Reminder
+
+When committing feature or plan changes, also update `docs/progress.json` to reflect completed tasks. Include the progress update in the plan commit or as a separate `docs(progress):` commit.
 
 ### Rules
 

--- a/.github/skills/create-implementation-plan/SKILL.md
+++ b/.github/skills/create-implementation-plan/SKILL.md
@@ -139,3 +139,4 @@ Plans in this project are living documents:
 - Prune after research: remove speculative options that were not chosen
 - Document reasoning: explain why alternatives were rejected
 - Plans serve as source of truth alongside the codebase
+- When tasks are completed, update `docs/progress.json` to reflect the new state (see `/development-process` Step 5b)

--- a/.github/skills/development-process/SKILL.md
+++ b/.github/skills/development-process/SKILL.md
@@ -167,9 +167,11 @@ cargo test -- --nocapture
 | `driver/*` | >80% |
 | `repl.rs` | >70% |
 
-## Step 5: Update Plans
+## Step 5: Update Plans and Progress Tracking
 
-After implementation, update the sub-plan document:
+After implementation, update both the sub-plan documents **and** the progress tracker.
+
+### 5a: Update Sub-Plan Document
 
 1. Mark completed steps with ✅
 2. Update acceptance criteria checkboxes
@@ -189,6 +191,23 @@ or
 ```markdown
 > **Status: DONE** — Completed [date], PR #XX
 ```
+
+### 5b: Update Progress Tracker (`docs/progress.json`)
+
+**This step is mandatory.** Every time tasks are completed, update `docs/progress.json`:
+
+1. Read the current `docs/progress.json`
+2. Update the relevant phase's `completed_tasks` count to match reality
+3. Update the phase `status`:
+   - `"not_started"` → `"in_progress"` when first task in a phase begins
+   - `"in_progress"` → `"completed"` when all tasks in the phase are done
+4. Set `started_date` when a phase transitions to `"in_progress"`
+5. Set `completed_date` when a phase transitions to `"completed"`
+6. Add an entry to `velocity.tasks_completed_log` with today's date, tasks done count, phase number, and PR reference
+7. Update `last_updated` to today's date
+8. Update `velocity.merged_prs` count
+
+Cross-check the phase task counts against `docs/plans/high-level-design.md` to ensure they match. The high-level design's task tables with ✅ markers are the source of truth for what is complete.
 
 ## Step 6: Update Documentation
 

--- a/.github/workflows/progress.yml
+++ b/.github/workflows/progress.yml
@@ -1,8 +1,7 @@
 name: Update Progress Roadmap
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
     paths:
       - 'docs/progress.json'
@@ -13,9 +12,6 @@ permissions:
 
 jobs:
   update-roadmap:
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,13 @@ cqlsh-rs is a ground-up Rust re-implementation of the Python `cqlsh` — the off
 - 100% compatibility with Python cqlsh is the primary constraint
 - Every feature must reference the compatibility matrix in the high-level design
 
+## Progress Tracking
+
+- **Always update `docs/progress.json`** when completing tasks or phases
+- Cross-check task counts against `docs/plans/high-level-design.md` (source of truth)
+- The `/development-process` skill Step 5b has detailed instructions for updating progress
+- A GitHub Action (`.github/workflows/progress.yml`) auto-generates the SVG roadmap when `progress.json` changes on main
+
 ## Commit Messages
 
 Use Conventional Commits format. See `/conventional-commit` skill for details.

--- a/docs/assets/progress-roadmap.svg
+++ b/docs/assets/progress-roadmap.svg
@@ -37,28 +37,36 @@
   <rect x="1" y="1" width="878" height="538" fill="none" stroke="#1e293b" stroke-width="2" rx="12"/>
   <text x="440" y="40" text-anchor="middle" font-family="monospace" font-size="20" font-weight="700" fill="#f8fafc">cqlsh-rs Development Roadmap</text>
   <text x="440" y="62" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#94a3b8">Rewriting cqlsh in Rust -- one semicolon at a time</text>
-  <text x="260" y="88" text-anchor="middle" font-family="monospace" font-size="13" fill="#e2e8f0">5/108 tasks (5%)</text>
-  <text x="600" y="88" text-anchor="middle" font-family="monospace" font-size="12" fill="#94a3b8">0.2 tasks/day  |  ~494 days remaining (ETA: Aug 2027)</text>
+  <text x="260" y="88" text-anchor="middle" font-family="monospace" font-size="13" fill="#e2e8f0">58/108 tasks (54%)</text>
+  <text x="600" y="88" text-anchor="middle" font-family="monospace" font-size="12" fill="#94a3b8">2.4 tasks/day  |  ~20 days remaining (ETA: Apr 2026)</text>
   <line x1="60" y1="100" x2="820" y2="100" stroke="#1e293b" stroke-width="1"/>
   <line x1="106.66666666666667" y1="195" x2="773.3333333333334" y2="195" stroke="#334155" stroke-width="8" stroke-linecap="round"/>
-  <line x1="106.66666666666667" y1="195" x2="151.11111111111111" y2="195" stroke="#f59e0b" stroke-width="8" stroke-linecap="round" opacity="0.6"/>
-  <circle class="pulse-ring-outer" cx="106.66666666666667" cy="195" r="32" fill="none" stroke="#f59e0b" stroke-width="2" opacity="0.25"/>
-  <circle class="pulse-ring" cx="106.66666666666667" cy="195" r="28" fill="none" stroke="#f59e0b" stroke-width="1.5" opacity="0.4"/>
-  <circle cx="106.66666666666667" cy="195" r="24" fill="#92400e" stroke="#f59e0b" stroke-width="3"/>
+  <line x1="106.66666666666667" y1="195" x2="240.0" y2="195" stroke="#22c55e" stroke-width="8" stroke-linecap="round" opacity="0.6"/>
+  <line x1="240.0" y1="195" x2="373.33333333333337" y2="195" stroke="#22c55e" stroke-width="8" stroke-linecap="round" opacity="0.6"/>
+  <line x1="373.33333333333337" y1="195" x2="506.6666666666667" y2="195" stroke="#22c55e" stroke-width="8" stroke-linecap="round" opacity="0.6"/>
+  <circle cx="106.66666666666667" cy="195" r="24" fill="#166534" stroke="#22c55e" stroke-width="3"/>
   <text x="106.66666666666667" y="201" text-anchor="middle" font-family="monospace" font-size="16" font-weight="700" fill="#fff">1</text>
   <text x="106.66666666666667" y="155" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="600" fill="#e2e8f0">Bootstrap MVP</text>
-  <text x="106.66666666666667" y="243" text-anchor="middle" font-family="monospace" font-size="10" fill="#94a3b8">5/15 tasks</text>
-  <text x="106.66666666666667" y="257" text-anchor="middle" font-family="monospace" font-size="10" font-weight="700" fill="#f59e0b">33%</text>
+  <text x="106.66666666666667" y="243" text-anchor="middle" font-family="monospace" font-size="10" fill="#94a3b8">15/15 tasks</text>
+  <text x="106.66666666666667" y="257" text-anchor="middle" font-family="monospace" font-size="10" font-weight="700" fill="#22c55e">100%</text>
+  <circle cx="106.66666666666667" cy="139" r="8" fill="#22c55e"/>
+  <path d="M102.66666666666667 139 l3 3 l5 -6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
   <text x="106.66666666666667" y="273" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#64748b">CLI, config, driver, basic REPL</text>
-  <circle cx="240.0" cy="195" r="24" fill="#334155" stroke="#64748b" stroke-width="3"/>
+  <circle cx="240.0" cy="195" r="24" fill="#166534" stroke="#22c55e" stroke-width="3"/>
   <text x="240.0" y="201" text-anchor="middle" font-family="monospace" font-size="16" font-weight="700" fill="#fff">2</text>
   <text x="240.0" y="155" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="600" fill="#e2e8f0">Usable Shell</text>
-  <text x="240.0" y="243" text-anchor="middle" font-family="monospace" font-size="10" fill="#94a3b8">0/22 tasks</text>
+  <text x="240.0" y="243" text-anchor="middle" font-family="monospace" font-size="10" fill="#94a3b8">22/22 tasks</text>
+  <text x="240.0" y="257" text-anchor="middle" font-family="monospace" font-size="10" font-weight="700" fill="#22c55e">100%</text>
+  <circle cx="240.0" cy="139" r="8" fill="#22c55e"/>
+  <path d="M236.0 139 l3 3 l5 -6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
   <text x="240.0" y="273" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#64748b">Line editing, formatting, core commands</text>
-  <circle cx="373.33333333333337" cy="195" r="24" fill="#334155" stroke="#64748b" stroke-width="3"/>
+  <circle cx="373.33333333333337" cy="195" r="24" fill="#166534" stroke="#22c55e" stroke-width="3"/>
   <text x="373.33333333333337" y="201" text-anchor="middle" font-family="monospace" font-size="16" font-weight="700" fill="#fff">3</text>
   <text x="373.33333333333337" y="155" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="600" fill="#e2e8f0">Tab Completion &amp; Output</text>
-  <text x="373.33333333333337" y="243" text-anchor="middle" font-family="monospace" font-size="10" fill="#94a3b8">0/21 tasks</text>
+  <text x="373.33333333333337" y="243" text-anchor="middle" font-family="monospace" font-size="10" fill="#94a3b8">21/21 tasks</text>
+  <text x="373.33333333333337" y="257" text-anchor="middle" font-family="monospace" font-size="10" font-weight="700" fill="#22c55e">100%</text>
+  <circle cx="373.33333333333337" cy="139" r="8" fill="#22c55e"/>
+  <path d="M369.33333333333337 139 l3 3 l5 -6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
   <text x="373.33333333333337" y="273" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#64748b">Completion engine, output formats, color</text>
   <circle cx="506.6666666666667" cy="195" r="24" fill="#334155" stroke="#64748b" stroke-width="3"/>
   <text x="506.6666666666667" y="201" text-anchor="middle" font-family="monospace" font-size="16" font-weight="700" fill="#fff">4</text>
@@ -75,8 +83,6 @@
   <text x="773.3333333333334" y="155" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="600" fill="#e2e8f0">Polish &amp; Release</text>
   <text x="773.3333333333334" y="243" text-anchor="middle" font-family="monospace" font-size="10" fill="#94a3b8">0/10 tasks</text>
   <text x="773.3333333333334" y="273" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#64748b">Releases, packaging, docs, migration</text>
-  <polygon points="100.66666666666667,123 112.66666666666667,123 106.66666666666667,131" fill="#fbbf24"/>
-  <text class="glow" x="106.66666666666667" y="119" text-anchor="middle" font-family="sans-serif" font-size="9" font-weight="700" fill="#fbbf24">YOU ARE HERE</text>
   <circle cx="300" cy="315" r="5" fill="#22c55e"/>
   <text x="310" y="319" font-family="sans-serif" font-size="11" fill="#cbd5e1">Completed</text>
   <circle cx="420" cy="315" r="5" fill="#f59e0b"/>
@@ -86,17 +92,41 @@
   <rect x="80" y="340" width="720" height="108" rx="6" fill="#1e293b" stroke="#475569" stroke-width="1"/>
   <rect x="80" y="340" width="720" height="24" rx="6" fill="#334155"/>
   <rect x="80" y="358" width="720" height="6" fill="#334155"/>
-  <text x="94" y="356" font-family="sans-serif" font-size="11" fill="#94a3b8">Copying 103 features to Rust...</text>
+  <text x="94" y="356" font-family="sans-serif" font-size="11" fill="#94a3b8">Copying 50 features to Rust...</text>
   <circle cx="782" cy="352" r="5" fill="#ef4444" opacity="0.6"/>
   <circle cx="766" cy="352" r="5" fill="#f59e0b" opacity="0.6"/>
   <circle cx="750" cy="352" r="5" fill="#22c55e" opacity="0.6"/>
   <rect x="90" y="383" width="700" height="20" rx="3" fill="#0f172a" stroke="#475569" stroke-width="1"/>
   <g clip-path="url(#barClip)">
-    <rect x="92" y="385" width="12" height="16" rx="2" fill="url(#barActive)" opacity="0.9"/>
-    <rect x="106" y="385" width="12" height="16" rx="2" fill="url(#barActive)" opacity="0.9"/>
+    <rect x="92" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="106" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="120" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="134" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="148" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="162" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="176" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="190" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="204" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="218" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="232" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="246" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="260" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="274" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="288" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="302" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="316" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="330" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="344" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="358" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="372" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="386" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="400" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="414" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="428" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
+    <rect x="442" y="385" width="12" height="16" rx="2" fill="url(#barFill)" opacity="0.9"/>
   </g>
-  <text x="440.0" y="397" text-anchor="middle" font-family="monospace" font-size="11" font-weight="700" fill="#fff" opacity="0.9">5%</text>
-  <text x="440.0" y="425" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#64748b" font-style="italic">About 1.4 years remaining... have you tried turning it off and on again?</text>
-  <text x="440.0" y="442" text-anchor="middle" font-family="monospace" font-size="8" fill="#475569">8 PRs merged  |  0.2 tasks/day  |  5 tasks done</text>
-  <text x="440" y="526" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#334155">Auto-generated from docs/progress.json  |  Last updated: 2026-03-13</text>
+  <text x="440.0" y="397" text-anchor="middle" font-family="monospace" font-size="11" font-weight="700" fill="#fff" opacity="0.9">54%</text>
+  <text x="440.0" y="425" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#64748b" font-style="italic">About 20 days remaining... 50 features to copy to Rust</text>
+  <text x="440.0" y="442" text-anchor="middle" font-family="monospace" font-size="8" fill="#475569">24 PRs merged  |  2.4 tasks/day  |  58 tasks done</text>
+  <text x="440" y="526" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#334155">Auto-generated from docs/progress.json  |  Last updated: 2026-03-25</text>
 </svg>

--- a/docs/progress.json
+++ b/docs/progress.json
@@ -1,14 +1,17 @@
 {
   "project": "cqlsh-rs",
-  "last_updated": "2026-03-13",
+  "last_updated": "2026-03-25",
   "velocity": {
     "started_date": "2026-03-01",
-    "merged_prs": 8,
+    "merged_prs": 24,
     "tasks_completed_log": [
       { "date": "2026-03-03", "tasks_done": 2, "phase": 1, "pr": "#1" },
       { "date": "2026-03-07", "tasks_done": 1, "phase": 1, "pr": "#3" },
       { "date": "2026-03-10", "tasks_done": 1, "phase": 1, "pr": "#5" },
-      { "date": "2026-03-13", "tasks_done": 1, "phase": 1, "pr": "#8" }
+      { "date": "2026-03-13", "tasks_done": 1, "phase": 1, "pr": "#8" },
+      { "date": "2026-03-15", "tasks_done": 10, "phase": 1, "pr": "#11" },
+      { "date": "2026-03-18", "tasks_done": 22, "phase": 2, "pr": "#17" },
+      { "date": "2026-03-22", "tasks_done": 21, "phase": 3, "pr": "#24" }
     ]
   },
   "phases": [
@@ -17,30 +20,30 @@
       "name": "Bootstrap MVP",
       "description": "CLI, config, driver, basic REPL",
       "total_tasks": 15,
-      "completed_tasks": 5,
-      "status": "in_progress",
+      "completed_tasks": 15,
+      "status": "completed",
       "started_date": "2026-03-01",
-      "completed_date": null
+      "completed_date": "2026-03-15"
     },
     {
       "id": 2,
       "name": "Usable Shell",
       "description": "Line editing, formatting, core commands",
       "total_tasks": 22,
-      "completed_tasks": 0,
-      "status": "not_started",
-      "started_date": null,
-      "completed_date": null
+      "completed_tasks": 22,
+      "status": "completed",
+      "started_date": "2026-03-15",
+      "completed_date": "2026-03-18"
     },
     {
       "id": 3,
       "name": "Tab Completion & Output",
       "description": "Completion engine, output formats, color",
       "total_tasks": 21,
-      "completed_tasks": 0,
-      "status": "not_started",
-      "started_date": null,
-      "completed_date": null
+      "completed_tasks": 21,
+      "status": "completed",
+      "started_date": "2026-03-18",
+      "completed_date": "2026-03-22"
     },
     {
       "id": 4,


### PR DESCRIPTION
## Summary

- **Update `docs/progress.json`** to reflect reality: Phase 1 (15/15), Phase 2 (22/22), Phase 3 (21/21) all completed — was stuck showing Phase 1 at 5/15
- **Fix `progress.yml` GitHub Action**: trigger on `push` to main instead of `pull_request` merge, since this repo uses direct pushes (all PRs show `merged=false`, so the old trigger never fired)
- **Add mandatory Step 5b** to the `development-process` skill with detailed instructions for updating `docs/progress.json` after completing tasks
- **Add `progress` scope** and tracking reminder to the `conventional-commit` skill
- **Add Progress Tracking section** to `CLAUDE.md` as a key project convention
- **Add progress reminder** to the `create-implementation-plan` skill
- **Regenerate `progress-roadmap.svg`** (now correctly shows 54% complete)

## Problem

`docs/progress.json` was last updated on 2026-03-13, showing only 5/108 tasks done. In reality, Phases 1-3 (58/108 tasks) are complete per the high-level design. The GitHub Action only triggered on PR merges, but this repo pushes directly to main, so the SVG was never regenerated automatically. No skill or documentation instructed developers to update progress.json.

## Test plan

- [x] Verify `progress.json` task counts match `high-level-design.md` phase tables
- [x] Verify SVG regenerates correctly (`python3 scripts/generate_progress_svg.py` → 54%)
- [ ] Verify `progress.yml` triggers on push to main with `docs/progress.json` path filter
- [ ] Verify development-process skill Step 5b instructions are clear and actionable

https://claude.ai/code/session_01Sks9pNgaYb8jBb8oNGbfee