### PR TITLE
Improve performance documentation with direct links and details

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ cqlsh-rs --completions fish > ~/.config/fish/completions/cqlsh-rs.fish
 Performance is tracked continuously via CI. Results are available at:
 
 - **[Historical Dashboard](https://fruch.github.io/cqlsh-rs/dev/bench/)** — Interactive commit-over-commit charts (updated on every merge to main)
-- **Job Summary** — Grouped benchmark tables posted to each CI run's summary page
-- **Rust vs Python** — Hyperfine startup comparison included in each benchmark run
+- **[Benchmark Workflow Runs](https://github.com/fruch/cqlsh-rs/actions/workflows/bench.yml)** — Grouped benchmark tables and Criterion artifacts posted to each CI run's summary page
+- **[Criterion Reports](https://github.com/fruch/cqlsh-rs/actions/workflows/bench.yml)** — Detailed HTML reports uploaded as artifacts on each run (retained 90 days)
+- **Rust vs Python** — Hyperfine startup comparison included in each benchmark run's job summary
 
 To run benchmarks locally:
 


### PR DESCRIPTION
## Summary
Updated the performance tracking documentation in README.md to provide clearer information about where benchmark results are published and how to access them.

## Changes
- Added direct link to the Benchmark Workflow Runs on GitHub Actions for easier access to CI run summaries
- Separated Criterion Reports into its own bullet point with details about HTML artifacts and 90-day retention policy
- Clarified that the Rust vs Python comparison is included in the job summary section

## Details
These documentation improvements help users better understand the performance tracking infrastructure by:
- Providing direct GitHub Actions workflow links instead of vague descriptions
- Explicitly documenting the availability and retention period of detailed Criterion HTML reports
- Making the structure more scannable with better separation of concerns between different benchmark result types

https://claude.ai/code/session_01HwgGQJeLayBZbniRhAXKBB