### PR TITLE
ci: upgrade GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,13 +36,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry & build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -74,14 +74,14 @@ jobs:
           cat startup-comparison.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload criterion HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: criterion-report-${{ github.sha }}
           path: target/criterion/
           retention-days: 90
 
       - name: Upload raw benchmark output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: benchmark-output-${{ github.sha }}
           path: bench_output.txt
@@ -132,18 +132,18 @@ jobs:
 
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: gh-pages
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: '.'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/ci-failure-analysis.yml
+++ b/.github/workflows/ci-failure-analysis.yml
@@ -21,13 +21,13 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
       # Download artifacts from the failed CI run
       - name: Download test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: test-results
           run-id: ${{ github.event.workflow_run.id }}
@@ -36,7 +36,7 @@ jobs:
         continue-on-error: true
 
       - name: Download clippy results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: clippy-results
           run-id: ${{ github.event.workflow_run.id }}
@@ -45,7 +45,7 @@ jobs:
         continue-on-error: true
 
       - name: Download build results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-results
           run-id: ${{ github.event.workflow_run.id }}
@@ -54,7 +54,7 @@ jobs:
         continue-on-error: true
 
       - name: Download fmt results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: fmt-results
           run-id: ${{ github.event.workflow_run.id }}
@@ -100,7 +100,7 @@ jobs:
       # Post or update PR comment
       - name: Post failure summary comment
         if: steps.pr.outputs.number != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const body = `${{ steps.analyze.outputs.comment }}`;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -25,7 +25,7 @@ jobs:
           cargo fmt --all -- --check 2>&1 | tee fmt-output.txt
       - name: Upload fmt results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: fmt-results
           path: fmt-output.txt
@@ -35,7 +35,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -46,7 +46,7 @@ jobs:
           cargo clippy --all-targets --all-features --message-format=json 2>&1 | tee clippy-output.json
       - name: Upload clippy results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: clippy-results
           path: clippy-output.json
@@ -61,7 +61,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable, beta]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -74,7 +74,7 @@ jobs:
           cargo nextest run --all-targets --all-features 2>&1 | tee test-output.log
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.rust }}
           path: test-output.log
@@ -89,7 +89,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable, beta]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -101,7 +101,7 @@ jobs:
           cargo build --release --message-format=json 2>&1 | tee build-output.json
       - name: Upload build results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-results-${{ matrix.os }}-${{ matrix.rust }}
           path: build-output.json
@@ -111,7 +111,7 @@ jobs:
     name: Integration Tests (ScyllaDB 6.0)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       # Temporary workaround: testcontainers-rs fails to start containers on
@@ -148,7 +148,7 @@ jobs:
         timeout-minutes: 15
       - name: Upload integration test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: integration-scylladb-results
           path: integration-scylladb-output.log
@@ -158,7 +158,7 @@ jobs:
     name: Integration Tests (Cassandra 4.1)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -192,7 +192,7 @@ jobs:
         timeout-minutes: 20
       - name: Upload integration test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: integration-cassandra-results
           path: integration-cassandra-output.log
@@ -202,7 +202,7 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -221,14 +221,14 @@ jobs:
             --output-dir coverage/
         timeout-minutes: 20
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: coverage/cobertura.xml
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report
           path: coverage/

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -13,7 +13,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: EndBug/label-sync@v2
         with:
           config-file: .github/labels.yml

--- a/.github/workflows/progress.yml
+++ b/.github/workflows/progress.yml
@@ -14,12 +14,12 @@ jobs:
   update-roadmap:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
## Summary
- Upgrade all GitHub Actions to versions that use Node.js 24, ahead of the June 2, 2026 forced deprecation of Node.js 20
- Updates across all 5 workflow files: `ci.yml`, `bench.yml`, `labels.yml`, `ci-failure-analysis.yml`, `progress.yml`
- `EndBug/label-sync@v2` and `benchmark-action/github-action-benchmark@v1` have no Node 24 releases yet — tracked for future update

### Version changes
| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | v4 | v5 |
| `actions/upload-artifact` | v4 | v6 |
| `actions/download-artifact` | v4 | v7 |
| `actions/cache` | v4 | v5 |
| `actions/configure-pages` | v5 | v6 |
| `actions/upload-pages-artifact` | v3 | v4 |
| `actions/deploy-pages` | v4 | v5 |
| `actions/setup-python` | v5 | v6 |
| `actions/github-script` | v7 | v8 |

## Test plan
- [ ] CI workflow passes (fmt, clippy, test, integration, build)
- [ ] Benchmark workflow runs successfully
- [ ] Progress workflow generates SVG correctly
- [ ] CI failure analysis workflow triggers on failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)