### PR TITLE
test: demo CI failure analysis (REVERT after verifying)

### DIFF
--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -21,7 +21,7 @@ fn version_flag_shows_version() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::contains("cqlsh"));
+        .stdout(predicate::str::contains("this-string-does-not-exist-in-version"));
 }
 
 #[test]

--- a/tests/integration/core_tests.rs
+++ b/tests/integration/core_tests.rs
@@ -28,6 +28,8 @@ fn test_simple_insert_and_select() {
     let output = execute_cql_output(scylla, &format!("SELECT * FROM {ks}.users WHERE id = 1"));
     assert!(output.contains("Alice"));
     assert!(output.contains("30"));
+    // Intentional failure to demo CI failure analysis
+    assert!(output.contains("DOES_NOT_EXIST"), "Demo: integration test intentionally broken");
 
     drop_test_keyspace(scylla, &ks);
 }


### PR DESCRIPTION
## Purpose

Demo PR to verify the CI failure analysis workflow posts a readable PR comment.

Intentionally breaks two tests:
- **Unit**: `version_flag_shows_version` — expects a non-existent string in version output
- **Integration**: `test_simple_insert_and_select` — asserts on `"DOES_NOT_EXIST"`

## Expected result

After CI fails, the `CI Failure Analysis` workflow should post a collapsed markdown comment here with:
- `<!-- cqlsh-rs-ci-summary -->` HTML marker
- Failed job count and classification
- `<details>` sections per failed job
- Re-run link in footer

## After verifying

Close this PR without merging.