### PR TITLE
fix(ci): restore customSmallerIsBetter tool for benchmark action

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -104,8 +104,8 @@ jobs:
       - name: Store results & track history
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          tool: 'criterion'
-          output-file-path: bench_output.txt
+          tool: 'customSmallerIsBetter'
+          output-file-path: output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Only push historical data on main merges (not PRs/schedule)
           auto-push: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## Summary
- The Node.js 24 upgrade commit (3728dc6) regressed the `benchmark-action` tool value from `customSmallerIsBetter` back to `criterion`, which is no longer valid in `github-action-benchmark@v1`
- Restores `tool: 'customSmallerIsBetter'` and `output-file-path: output.json` (generated by `format_bench_summary.py`)

## Test plan
- [ ] Benchmark workflow passes on this PR (trigger manually or add `benchmark` label)
- [ ] "Store results & track history" step no longer errors with invalid tool value

🤖 Generated with [Claude Code](https://claude.com/claude-code)