### PR TITLE
fix(ci): update macOS runner from macos-13 to macos-14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
             cross: true
             artifact: cqlsh-rs
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-14
             cross: false
             artifact: cqlsh-rs
           - target: aarch64-apple-darwin


### PR DESCRIPTION
## Summary

- Update `x86_64-apple-darwin` build runner from deprecated `macos-13` to `macos-14` in the release workflow
- Fixes the v0.1.0 release pipeline failure: `The configuration 'macos-13-us-default' is not supported`
- Cross-compilation to x86_64 works natively via Rust toolchain; Rosetta 2 handles test execution

## Test plan

- [ ] Re-run the release workflow and verify the `x86_64-apple-darwin` build job succeeds
- [ ] Verify the produced binary is a valid x86_64 Mach-O executable

Fixes: https://github.com/fruch/cqlsh-rs/actions/runs/23767706685

🤖 Generated with [Claude Code](https://claude.com/claude-code)