### PR TITLE
fix(ci): fix GitHub Pages docs deployment conflicts

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,7 +1,7 @@
 # Benchmark CI — tracks performance across merges and on-demand for PRs.
 #
 # Triggers:
-#   - Every push to main (historical tracking + GitHub Pages deploy)
+#   - Every push to main (historical tracking)
 #   - PRs with the "benchmark" label (regression alerts on every push)
 #   - Weekly Monday 06:00 UTC (catch dependency regressions)
 #   - Manual dispatch
@@ -23,8 +23,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  pages: write
-  id-token: write
 
 jobs:
   benchmark:
@@ -119,31 +117,3 @@ jobs:
           # Historical data location on gh-pages branch
           benchmark-data-dir-path: 'dev/bench'
 
-  # Deploy GitHub Pages dashboard with historical benchmark charts.
-  # Only runs on main pushes (after benchmark data is pushed to gh-pages).
-  deploy-pages:
-    needs: benchmark
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@v5
-        with:
-          ref: gh-pages
-
-      - name: Configure GitHub Pages
-        uses: actions/configure-pages@v6
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: '.'
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,12 +5,15 @@ on:
     branches: [main]
     paths:
       - 'docs/book/**'
+      - 'src/**'
+      - 'Cargo.toml'
       - '.github/workflows/docs.yml'
   pull_request:
     branches: [main]
     paths:
       - 'docs/book/**'
       - '.github/workflows/docs.yml'
+  workflow_dispatch:
 
 # Allow only one concurrent deployment
 concurrency:
@@ -48,6 +51,19 @@ jobs:
         run: |
           cp docs/llms.txt docs/book/book/llms.txt
           cp docs/llms-full.txt docs/book/book/llms-full.txt
+
+      - name: Merge benchmark dashboard from gh-pages
+        run: |
+          git fetch origin gh-pages:gh-pages || true
+          if git rev-parse --verify gh-pages >/dev/null 2>&1; then
+            git show gh-pages:dev/bench/index.html > /dev/null 2>&1 && {
+              mkdir -p docs/book/book/dev/bench
+              git show gh-pages:dev/bench/index.html > docs/book/book/dev/bench/index.html
+              git show gh-pages:dev/bench/data.js > docs/book/book/dev/bench/data.js
+            } || echo "No benchmark data on gh-pages yet"
+          else
+            echo "gh-pages branch not found, skipping benchmark merge"
+          fi
 
       - name: Upload artifact
         if: github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A ground-up Rust re-implementation of the Python `cqlsh` — the official intera
 - **Cross-platform** — Linux, macOS, and Windows (x86_64 & ARM64)
 - **Fast** — sub-millisecond startup, async I/O with Tokio
 
+**[Documentation](https://fruch.github.io/cqlsh-rs/)** | **[API Reference](https://fruch.github.io/cqlsh-rs/api/cqlsh_rs/)** | **[Benchmarks](https://fruch.github.io/cqlsh-rs/dev/bench/)**
+
 ## Development Progress
 
 <p align="center">


### PR DESCRIPTION
## Summary

The docs site at https://fruch.github.io/cqlsh-rs/ wasn't working because `bench.yml` had a competing `deploy-pages` job that overwrote the mdBook deployment with just benchmark data.

- **Remove `deploy-pages` job from `bench.yml`** — benchmarks still push data to `gh-pages` via `auto-push`; the docs workflow handles Pages deployment
- **Add benchmark dashboard merge step to `docs.yml`** — pulls `/dev/bench/` data from the `gh-pages` branch so benchmarks are included in the deployed site alongside mdBook and rustdoc
- **Broaden `docs.yml` triggers** — also triggers on `src/**` and `Cargo.toml` changes (for rustdoc updates) and `workflow_dispatch` (manual re-deploy)
- **Add documentation links to README** — docs site, API reference, benchmarks

## Test plan

- [x] Merge to main, then manually trigger the Documentation workflow via `workflow_dispatch`
- [ ] Confirm https://fruch.github.io/cqlsh-rs/ shows the mdBook documentation
- [ ] Confirm https://fruch.github.io/cqlsh-rs/api/cqlsh_rs/ shows rustdoc
- [ ] Confirm https://fruch.github.io/cqlsh-rs/dev/bench/ shows the benchmark dashboard
- [ ] Verify bench workflow still pushes benchmark data without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)