### PR TITLE
feat: add --cqlversion and --protocol-version compatibility warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 .worktrees/
+integration-output.log

--- a/src/driver/scylla_driver.rs
+++ b/src/driver/scylla_driver.rs
@@ -452,6 +452,11 @@ impl CqlDriver for ScyllaDriver {
             builder = builder.tls_context(Some(tls_config));
         }
 
+        // NOTE: config.protocol_version is accepted for CLI compatibility but
+        // scylla-rust-driver 1.5.0 auto-negotiates the native protocol version.
+        // SessionBuilder has no method to force a specific protocol version.
+        // Similarly, the driver hardcodes CQL_VERSION="4.0.0" in the STARTUP frame.
+
         let session = builder.build().await.context("connecting to cluster")?;
 
         Ok(ScyllaDriver {

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,23 @@ async fn main() -> Result<()> {
         print_banner(&session);
     }
 
+    // Warn about driver limitations for compatibility-only flags
+    if let Some(ref requested) = config.cqlversion {
+        let actual = session.cql_version.as_deref().unwrap_or("unknown");
+        if requested != actual {
+            eprintln!(
+                "Warning: --cqlversion {requested} requested, but the server reports CQL spec {actual}. \
+                 The scylla driver does not support overriding the CQL version."
+            );
+        }
+    }
+    if config.protocol_version.is_some() {
+        eprintln!(
+            "Warning: --protocol-version is accepted for CLI compatibility but the scylla \
+             driver auto-negotiates the native protocol version."
+        );
+    }
+
     if config.execute.is_some() || config.file.is_some() {
         // Non-interactive execution mode (-e or -f)
         let exit_code = execute_noninteractive(&mut session, &config).await;


### PR DESCRIPTION
## Summary

- **`--cqlversion`**: Accepted for CLI compatibility. Warns when the requested version differs from the server's reported CQL spec, since the scylla driver hardcodes `CQL_VERSION=4.0.0` and cannot override it.
- **`--protocol-version`**: Accepted for CLI compatibility. Warns that the scylla driver auto-negotiates the native protocol version (no `SessionBuilder` API to force it).
- Adds 2 CLI tests verifying both flags are accepted without panic.
- Adds `integration-output.log` to `.gitignore`.

## Context

Phase 4 remaining tasks: these two flags were already parsed by clap but had no runtime behavior. Python cqlsh accepts them, so we match that behavior with informational warnings about driver limitations.