### PR TITLE
fix: emit ANSI clear sequences for CLEAR/CLS in non-interactive mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -366,11 +366,16 @@ async fn execute_single_statement(
         return true;
     }
 
+    // Handle CLEAR/CLS in non-interactive mode by emitting ANSI escape sequences
+    // (matches Python cqlsh behavior expected by dtest test_clear)
+    if upper == "CLEAR" || upper == "CLS" {
+        print!("\x1B[2J\x1B[1;1H");
+        return true;
+    }
+
     // Skip commands that don't make sense in non-interactive mode
     if upper == "QUIT"
         || upper == "EXIT"
-        || upper == "CLEAR"
-        || upper == "CLS"
         || upper == "HELP"
         || upper == "?"
         || upper.starts_with("HELP ")


### PR DESCRIPTION
## Summary

- CLEAR/CLS was silently ignored in non-interactive mode, but Python cqlsh emits ANSI escape sequences (`\x1B[2J\x1B[1;1H`) that dtests (`test_clear`) assert on
- Moved CLEAR/CLS handling before the "silently ignore" block so it emits the escape sequences, matching Python cqlsh behavior

Closes #66