### PR TITLE
fix: use microsecond precision (6 digits) for timestamp formatting

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -319,7 +319,7 @@ fn format_timestamp(millis: i64, options: &CopyOptions) -> String {
             let utc: DateTime<Utc> = dt;
             match &options.datetime_format {
                 Some(fmt) => utc.format(fmt).to_string(),
-                None => utc.format("%Y-%m-%d %H:%M:%S%.3f%z").to_string(),
+                None => utc.format("%Y-%m-%d %H:%M:%S%.6f%z").to_string(),
             }
         }
         None => format!("<invalid timestamp: {millis}>"),
@@ -1085,7 +1085,7 @@ fn cql_value_to_insert_literal(v: &CqlValue) -> String {
             match DateTime::from_timestamp_millis(*ms) {
                 Some(dt) => {
                     let utc: DateTime<Utc> = dt;
-                    format!("'{}'", utc.format("%Y-%m-%d %H:%M:%S%.3f+0000"))
+                    format!("'{}'", utc.format("%Y-%m-%d %H:%M:%S%.6f+0000"))
                 }
                 None => format!("{ms}"),
             }

--- a/src/driver/types.rs
+++ b/src/driver/types.rs
@@ -223,7 +223,7 @@ fn format_timestamp(f: &mut fmt::Formatter<'_>, millis: i64) -> fmt::Result {
     match dt {
         Some(dt) => {
             let utc: DateTime<Utc> = dt;
-            write!(f, "{}", utc.format("%Y-%m-%d %H:%M:%S%.3f%z"))
+            write!(f, "{}", utc.format("%Y-%m-%d %H:%M:%S%.6f%z"))
         }
         None => write!(f, "<invalid timestamp: {millis}>"),
     }


### PR DESCRIPTION
## Summary

- Timestamp output used `%.3f` (3 decimal places / milliseconds) instead of `%.6f` (6 decimal places / microseconds)
- Changed format strings in `types.rs` (display) and `copy.rs` (COPY TO output) to `%.6f`
- Parsing format strings left unchanged — they already accept variable precision via `%.f`
- Matches Python cqlsh behavior, fixes dtest `test_past_and_future_dates`

Closes #64