### PR TITLE
fix: print connect/request timeout and ssl in --debug mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,13 @@ async fn main() -> Result<()> {
     let config = load_config(&cli)?;
 
     if cli.debug {
+        eprintln!("Using CQL driver: scylla-rust-driver");
+        eprintln!("Using connect timeout: {} seconds", config.connect_timeout);
+        eprintln!("Using request timeout: {} seconds", config.request_timeout);
+        eprintln!("Using '{}' encoding", config.encoding);
+        eprintln!("Using ssl: {}", config.ssl);
         eprintln!("Debug: resolved host={}, port={}", config.host, config.port);
         eprintln!("Debug: cqlshrc path={}", config.cqlshrc_path.display());
-        eprintln!("Debug: encoding={}", config.encoding);
         if let Some(ref v) = config.cqlversion {
             eprintln!("Debug: cqlversion={v}");
         }


### PR DESCRIPTION
## Summary

- Added Python cqlsh-compatible debug output lines: CQL driver, connect timeout, request timeout, encoding, and ssl status
- The dtest `test_connect_timeout` asserts `"Using connect timeout: 10 seconds"` in stderr — this was missing
- Existing debug lines (host, port, cqlshrc path, cqlversion, protocol_version, tty) are preserved

### Debug output now looks like:
```
Using CQL driver: scylla-rust-driver
Using connect timeout: 5 seconds
Using request timeout: 10 seconds
Using 'utf-8' encoding
Using ssl: false
Debug: resolved host=127.0.0.1, port=9042
Debug: cqlshrc path=/home/user/.cassandra/cqlshrc
```

Closes #65