### PR TITLE
fix: suppress tracing output for queries against system_traces

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -417,7 +417,7 @@ async fn execute_single_statement(
             }
 
             // Print trace info if tracing is enabled
-            if session.is_tracing_enabled() {
+            if session.is_tracing_enabled() && !upper.contains("SYSTEM_TRACES") {
                 if let Some(trace_id) = result.tracing_id {
                     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                     match session.get_trace_session(trace_id).await {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -672,7 +672,7 @@ fn dispatch_input<'a>(
                 }
 
                 // Print trace info if tracing is enabled
-                if session.is_tracing_enabled() {
+                if session.is_tracing_enabled() && !upper_stmt.contains("SYSTEM_TRACES") {
                     if let Some(trace_id) = result.tracing_id {
                         // Brief delay to allow trace data to propagate
                         tokio::time::sleep(std::time::Duration::from_millis(500)).await;


### PR DESCRIPTION
## Summary

- When TRACING ON is active, queries targeting `system_traces` tables no longer display their own tracing output
- Python cqlsh suppresses tracing for system_traces queries to avoid recursive trace-of-trace output
- Check added in both interactive (repl.rs) and non-interactive (main.rs) code paths

Fixes dtest `test_tracing_from_system_traces`.

Closes #72