### PR TITLE
fix: correct DESCRIBE TABLE column ordering, add WITH clause, and include MVs in DESCRIBE KEYSPACE

### DIFF
--- a/src/describe.rs
+++ b/src/describe.rs
@@ -229,6 +229,8 @@ async fn describe_keyspace(
         write_table_indexes(session, ks_name, &table.name, writer).await?;
     }
 
+    write_keyspace_materialized_views(session, ks_name, writer).await?;
+
     writeln!(writer)?;
     Ok(())
 }
@@ -868,7 +870,60 @@ fn write_create_table(writer: &mut dyn Write, meta: &crate::driver::TableMetadat
         }
     }
 
-    writeln!(writer, ");")?;
+    writeln!(writer, ")")?;
+
+    let mut first_with = true;
+
+    if !meta.clustering_key.is_empty() {
+        let order_parts: Vec<String> = meta
+            .clustering_key
+            .iter()
+            .enumerate()
+            .map(|(i, name)| {
+                let order = meta
+                    .clustering_order
+                    .get(i)
+                    .map(|s| s.as_str())
+                    .unwrap_or("ASC");
+                format!("{} {}", quote_if_needed(name), order)
+            })
+            .collect();
+        write!(
+            writer,
+            " WITH CLUSTERING ORDER BY ({})",
+            order_parts.join(", ")
+        )?;
+        first_with = false;
+    }
+
+    let prop_order = [
+        "bloom_filter_fp_chance",
+        "caching",
+        "comment",
+        "compaction",
+        "compression",
+        "crc_check_chance",
+        "default_time_to_live",
+        "gc_grace_seconds",
+        "max_index_interval",
+        "memtable_flush_period_in_ms",
+        "min_index_interval",
+        "speculative_retry",
+    ];
+
+    for prop_name in &prop_order {
+        if let Some(value) = meta.properties.get(*prop_name) {
+            let formatted_value = format_property_value(prop_name, value);
+            if first_with {
+                write!(writer, " WITH {} = {}", prop_name, formatted_value)?;
+                first_with = false;
+            } else {
+                write!(writer, "\n    AND {} = {}", prop_name, formatted_value)?;
+            }
+        }
+    }
+
+    writeln!(writer, ";")?;
     Ok(())
 }
 
@@ -910,6 +965,28 @@ async fn write_table_indexes(
             quote_if_needed(&tbl_name),
             target
         )?;
+    }
+
+    Ok(())
+}
+
+async fn write_keyspace_materialized_views(
+    session: &CqlSession,
+    keyspace: &str,
+    writer: &mut dyn Write,
+) -> Result<()> {
+    let query = format!(
+        "SELECT view_name FROM system_schema.views WHERE keyspace_name = '{}'",
+        keyspace.replace('\'', "''")
+    );
+    let result = session.execute_query(&query).await?;
+
+    for row in &result.rows {
+        if let Some(view_name) = row.get(0) {
+            let view_name = view_name.to_string();
+            writeln!(writer)?;
+            describe_materialized_view(session, &format!("{keyspace}.{view_name}"), writer).await?;
+        }
     }
 
     Ok(())
@@ -995,6 +1072,14 @@ fn extract_map_value(map_str: &str, key: &str) -> Option<String> {
         }
     }
     None
+}
+
+fn format_property_value(name: &str, value: &str) -> String {
+    match name {
+        "comment" | "speculative_retry" => format!("'{}'", value.replace('\'', "''")),
+        "caching" | "compaction" | "compression" => value.to_string(),
+        _ => value.to_string(),
+    }
 }
 
 /// Check if a keyspace is a system keyspace.
@@ -1289,6 +1374,8 @@ mod tests {
             ],
             partition_key: vec!["id".to_string()],
             clustering_key: vec![],
+            clustering_order: vec![],
+            properties: std::collections::BTreeMap::new(),
         };
 
         let mut buf = Vec::new();
@@ -1323,12 +1410,18 @@ mod tests {
             ],
             partition_key: vec!["user_id".to_string()],
             clustering_key: vec!["event_time".to_string()],
+            clustering_order: vec!["ASC".to_string()],
+            properties: std::collections::BTreeMap::new(),
         };
 
         let mut buf = Vec::new();
         write_create_table(&mut buf, &meta).unwrap();
         let output = String::from_utf8(buf).unwrap();
         assert!(output.contains("PRIMARY KEY (user_id, event_time)"));
+        assert!(
+            output.contains("WITH CLUSTERING ORDER BY (event_time ASC)"),
+            "expected CLUSTERING ORDER BY: {output}"
+        );
     }
 
     #[test]
@@ -1358,6 +1451,8 @@ mod tests {
             ],
             partition_key: vec!["host".to_string(), "metric".to_string()],
             clustering_key: vec!["ts".to_string()],
+            clustering_order: vec!["ASC".to_string()],
+            properties: std::collections::BTreeMap::new(),
         };
 
         let mut buf = Vec::new();

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -82,6 +82,11 @@ pub struct TableMetadata {
     pub columns: Vec<ColumnMetadata>,
     pub partition_key: Vec<String>,
     pub clustering_key: Vec<String>,
+    /// Clustering order for each clustering column (e.g., "ASC" or "DESC").
+    /// Parallel to `clustering_key`.
+    pub clustering_order: Vec<String>,
+    /// Table properties from system_schema.tables (e.g., bloom_filter_fp_chance, compaction, etc.).
+    pub properties: std::collections::BTreeMap<String, String>,
 }
 
 /// Metadata about a user-defined type (UDT).

--- a/src/driver/scylla_driver.rs
+++ b/src/driver/scylla_driver.rs
@@ -679,54 +679,128 @@ impl CqlDriver for ScyllaDriver {
     }
 
     async fn get_tables(&self, keyspace: &str) -> Result<Vec<TableMetadata>> {
+        let ks_escaped = keyspace.replace('\'', "''");
+
         let result = self
             .execute_unpaged(&format!(
-                "SELECT table_name FROM system_schema.tables WHERE keyspace_name = '{}'",
-                keyspace.replace('\'', "''")
+                "SELECT table_name FROM system_schema.tables WHERE keyspace_name = '{ks_escaped}'"
             ))
             .await?;
 
         let mut tables = Vec::new();
         for row in &result.rows {
             let table_name = row.get(0).and_then(cql_value_to_string).unwrap_or_default();
+            let tbl_escaped = table_name.replace('\'', "''");
 
             let col_result = self
                 .execute_unpaged(&format!(
-                    "SELECT column_name, type, kind \
+                    "SELECT column_name, type, kind, position, clustering_order \
                      FROM system_schema.columns \
-                     WHERE keyspace_name = '{}' AND table_name = '{}'",
-                    keyspace.replace('\'', "''"),
-                    table_name.replace('\'', "''")
+                     WHERE keyspace_name = '{ks_escaped}' AND table_name = '{tbl_escaped}'"
                 ))
                 .await?;
 
-            let mut columns = Vec::new();
-            let mut partition_key = Vec::new();
-            let mut clustering_key = Vec::new();
+            let mut pk_cols: Vec<(i32, String, String)> = Vec::new();
+            let mut ck_cols: Vec<(i32, String, String, String)> = Vec::new();
+            let mut regular_cols: Vec<(String, String)> = Vec::new();
 
             for col_row in &col_result.rows {
                 let col_name = col_row
-                    .get(0)
-                    .and_then(cql_value_to_string)
+                    .get_by_name("column_name", &col_result.columns)
+                    .map(|v| v.to_string())
                     .unwrap_or_default();
                 let col_type = col_row
-                    .get(1)
-                    .and_then(cql_value_to_string)
+                    .get_by_name("type", &col_result.columns)
+                    .map(|v| v.to_string())
                     .unwrap_or_default();
                 let kind = col_row
-                    .get(2)
-                    .and_then(cql_value_to_string)
+                    .get_by_name("kind", &col_result.columns)
+                    .map(|v| v.to_string())
                     .unwrap_or_default();
-
-                columns.push(ColumnMetadata {
-                    name: col_name.clone(),
-                    type_name: col_type,
-                });
+                let position = col_row
+                    .get_by_name("position", &col_result.columns)
+                    .and_then(|v| v.to_string().parse::<i32>().ok())
+                    .unwrap_or(0);
+                let clustering_order = col_row
+                    .get_by_name("clustering_order", &col_result.columns)
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "none".to_string());
 
                 match kind.as_str() {
-                    "partition_key" => partition_key.push(col_name),
-                    "clustering" => clustering_key.push(col_name),
-                    _ => {}
+                    "partition_key" => pk_cols.push((position, col_name, col_type)),
+                    "clustering" => ck_cols.push((position, col_name, col_type, clustering_order)),
+                    _ => regular_cols.push((col_name, col_type)),
+                }
+            }
+
+            pk_cols.sort_by_key(|c| c.0);
+            ck_cols.sort_by_key(|c| c.0);
+
+            let partition_key: Vec<String> = pk_cols.iter().map(|c| c.1.clone()).collect();
+            let clustering_key: Vec<String> = ck_cols.iter().map(|c| c.1.clone()).collect();
+            let clustering_order: Vec<String> = ck_cols
+                .iter()
+                .map(|c| {
+                    let order = c.3.to_uppercase();
+                    if order == "NONE" || order.is_empty() {
+                        "ASC".to_string()
+                    } else {
+                        order
+                    }
+                })
+                .collect();
+
+            let mut columns: Vec<ColumnMetadata> = Vec::new();
+            for (_, name, typ) in &pk_cols {
+                columns.push(ColumnMetadata {
+                    name: name.clone(),
+                    type_name: typ.clone(),
+                });
+            }
+            for (_, name, typ, _) in &ck_cols {
+                columns.push(ColumnMetadata {
+                    name: name.clone(),
+                    type_name: typ.clone(),
+                });
+            }
+            for (name, typ) in &regular_cols {
+                columns.push(ColumnMetadata {
+                    name: name.clone(),
+                    type_name: typ.clone(),
+                });
+            }
+
+            let props_result = self
+                .execute_unpaged(&format!(
+                    "SELECT bloom_filter_fp_chance, caching, comment, compaction, compression, \
+                     crc_check_chance, default_time_to_live, gc_grace_seconds, \
+                     max_index_interval, memtable_flush_period_in_ms, min_index_interval, \
+                     speculative_retry \
+                     FROM system_schema.tables \
+                     WHERE keyspace_name = '{ks_escaped}' AND table_name = '{tbl_escaped}'"
+                ))
+                .await?;
+
+            let mut properties = std::collections::BTreeMap::new();
+            if let Some(props_row) = props_result.rows.first() {
+                let prop_names = [
+                    "bloom_filter_fp_chance",
+                    "caching",
+                    "comment",
+                    "compaction",
+                    "compression",
+                    "crc_check_chance",
+                    "default_time_to_live",
+                    "gc_grace_seconds",
+                    "max_index_interval",
+                    "memtable_flush_period_in_ms",
+                    "min_index_interval",
+                    "speculative_retry",
+                ];
+                for prop_name in &prop_names {
+                    if let Some(val) = props_row.get_by_name(prop_name, &props_result.columns) {
+                        properties.insert(prop_name.to_string(), val.to_string());
+                    }
                 }
             }
 
@@ -736,6 +810,8 @@ impl CqlDriver for ScyllaDriver {
                 columns,
                 partition_key,
                 clustering_key,
+                clustering_order,
+                properties,
             });
         }
 

--- a/src/schema_cache.rs
+++ b/src/schema_cache.rs
@@ -226,6 +226,8 @@ mod tests {
                 .collect(),
             partition_key: vec![],
             clustering_key: vec![],
+            clustering_order: vec![],
+            properties: std::collections::BTreeMap::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

- **#89**: Fix column ordering in `DESCRIBE TABLE` — columns now appear in schema definition order (partition keys → clustering keys → regular) instead of alphabetical
- **#90**: Add `WITH` clause to `DESCRIBE TABLE` output including `CLUSTERING ORDER BY` and all table properties (compaction, compression, gc_grace_seconds, etc.)
- **#91**: Include materialized view definitions in `DESCRIBE KEYSPACE` output

## Changes

- **`src/driver/mod.rs`**: Added `clustering_order` and `properties` fields to `TableMetadata`
- **`src/driver/scylla_driver.rs`**: Rewrote `get_tables()` to fetch column position/clustering_order, sort columns correctly, and query table properties from `system_schema.tables`
- **`src/describe.rs`**: Extended `write_create_table()` with WITH clause generation; added `write_keyspace_materialized_views()` for DESCRIBE KEYSPACE; added `format_property_value()` helper
- **`src/schema_cache.rs`**: Updated test helper

## Testing

- `cargo build` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test --lib` — 465 tests pass ✅

Closes #89, closes #90, closes #91