### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/scylladb/cqlsh-rs/compare/v0.2.0...v0.2.1) - 2026-04-20
+
+### Fixed
+
+- add WITH clause to DESCRIBE MATERIALIZED VIEW output
+
 ## [0.2.0](https://github.com/scylladb/cqlsh-rs/compare/v0.1.0...v0.2.0) - 2026-04-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/scylladb/cqlsh-rs/compare/v0.2.0...v0.2.1) - 2026-04-20

### Fixed

- add WITH clause to DESCRIBE MATERIALIZED VIEW output
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).