### PR TITLE
fix(describe): restore accidentally deleted format_property_value function

### DIFF
--- a/src/describe.rs
+++ b/src/describe.rs
@@ -1267,6 +1267,18 @@ fn format_create_mv_ddl(parts: &MvDdlParts<'_>) -> String {
     out
 }
 
+/// Format a table/MV property value for DDL output.
+///
+/// String-like properties (comment, speculative_retry) are single-quoted;
+/// map-like properties (caching, compaction, compression) are emitted as-is.
+fn format_property_value(name: &str, value: &str) -> String {
+    match name {
+        "comment" | "speculative_retry" => format!("'{}'", value.replace('\'', "''")),
+        "caching" | "compaction" | "compression" => value.to_string(),
+        _ => value.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- **Restore `format_property_value`** — accidentally deleted in 4703a88 as collateral damage from an unrelated COPY TO/FROM fix
- Fixes compilation failure on `main`: `error[E0425]: cannot find function format_property_value in this scope`

## Root Cause

Commit `4703a88` ("fix(copy): handle COPY TO/FROM client-side") removed a large chunk of `write_create_table` including the `format_property_value` helper function. The call site in `format_create_mv_ddl` survived, creating a broken build.

## Changes

- `src/describe.rs`: Re-add the `format_property_value` function before the test module