### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/scylladb/cqlsh-rs/compare/v0.2.0...v0.3.0) - 2026-04-20
+
+### Fixed
+
+- *(describe)* restore accidentally deleted format_property_value function
+- *(copy)* handle COPY TO/FROM client-side instead of sending to server
+- add WITH clause to DESCRIBE MATERIALIZED VIEW output
+
 ## [0.2.0](https://github.com/scylladb/cqlsh-rs/compare/v0.1.0...v0.2.0) - 2026-04-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `cqlsh-rs` breaking changes

```text
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field clustering_order of struct TableMetadata, previously in file /tmp/.tmpfRV6fz/cqlsh-rs/src/driver/mod.rs:87
  field properties of struct TableMetadata, previously in file /tmp/.tmpfRV6fz/cqlsh-rs/src/driver/mod.rs:89
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/scylladb/cqlsh-rs/compare/v0.2.0...v0.3.0) - 2026-04-20

### Fixed

- *(describe)* restore accidentally deleted format_property_value function
- *(copy)* handle COPY TO/FROM client-side instead of sending to server
- add WITH clause to DESCRIBE MATERIALIZED VIEW output
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).