### PR TITLE
fix: handle LOGIN command in non-interactive mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -498,6 +498,35 @@ fn execute_single_statement<'a>(
             return true;
         }
 
+        // Handle LOGIN in non-interactive mode (reconnect with new credentials)
+        if upper == "LOGIN" {
+            eprintln!("Usage: LOGIN <username> [<password>]");
+            return false;
+        }
+        if upper.starts_with("LOGIN ") {
+            let args = trimmed["LOGIN ".len()..].trim();
+            let parts: Vec<&str> = args.splitn(2, char::is_whitespace).collect();
+            let new_user = parts[0].to_string();
+            let new_pass = if parts.len() > 1 {
+                Some(parts[1].trim_matches('\'').to_string())
+            } else {
+                None
+            };
+            let mut new_config = config.clone();
+            new_config.username = Some(new_user);
+            new_config.password = new_pass;
+            match cqlsh_rs::session::CqlSession::connect(&new_config).await {
+                Ok(new_session) => {
+                    *session = new_session;
+                }
+                Err(e) => {
+                    eprintln!("{}", cqlsh_rs::error::format_error_colored(&e, colorizer));
+                    return false;
+                }
+            }
+            return true;
+        }
+
         // Skip commands that don't make sense in non-interactive mode
         if upper == "QUIT"
             || upper == "EXIT"
@@ -514,8 +543,6 @@ fn execute_single_statement<'a>(
             || upper == "CAPTURE"
             || upper == "CAPTURE OFF"
             || upper.starts_with("CAPTURE ")
-            || upper == "LOGIN"
-            || upper.starts_with("LOGIN ")
         {
             // Silently ignore interactive-only commands
             return true;

--- a/tests/integration/login_tests.rs
+++ b/tests/integration/login_tests.rs
@@ -1,0 +1,66 @@
+//! Integration tests for LOGIN command in non-interactive mode.
+
+use predicates::prelude::*;
+
+use super::helpers::*;
+
+#[test]
+#[ignore = "requires Docker"]
+fn login_bare_shows_usage_on_stderr() {
+    let scylla = get_scylla();
+    cqlsh_cmd(scylla)
+        .args(["-e", "LOGIN"])
+        .assert()
+        .stderr(predicate::str::contains("Usage: LOGIN"))
+        .code(1);
+}
+
+#[test]
+#[ignore = "requires Docker"]
+fn login_with_credentials_reconnects_and_queries() {
+    let scylla = get_scylla();
+    cqlsh_cmd(scylla)
+        .args([
+            "-e",
+            "LOGIN cassandra 'cassandra'; SELECT key FROM system.local",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("local"));
+}
+
+#[test]
+#[ignore = "requires Docker"]
+fn login_username_only_reconnects() {
+    let scylla = get_scylla();
+    cqlsh_cmd(scylla)
+        .args(["-e", "LOGIN cassandra; SELECT key FROM system.local"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("local"));
+}
+
+#[test]
+#[ignore = "requires Docker"]
+fn login_via_stdin_reconnects_and_runs_next_statement() {
+    let scylla = get_scylla();
+    cqlsh_cmd(scylla)
+        .write_stdin("LOGIN cassandra 'cassandra';\nSELECT key FROM system.local;\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("local"));
+}
+
+#[test]
+#[ignore = "requires Docker"]
+fn login_multiple_times_in_sequence() {
+    let scylla = get_scylla();
+    cqlsh_cmd(scylla)
+        .args([
+            "-e",
+            "LOGIN cassandra 'cassandra'; LOGIN cassandra 'cassandra'; SELECT key FROM system.local",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("local"));
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -12,6 +12,7 @@ mod core_tests;
 mod describe_tests;
 mod escape_tests;
 mod helpers;
+mod login_tests;
 mod output_tests;
 mod ssl_tests;
 mod unicode_tests;


### PR DESCRIPTION
## Summary
- LOGIN was silently ignored in non-interactive/batch mode, causing dtests to fail
- Now handles LOGIN by reconnecting with new credentials (matching interactive REPL behavior)
- Auth errors are output to stderr using the standard error formatter

Closes #108