### PR TITLE
feat: warn on schema version mismatch after connect

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,14 @@ async fn main() -> Result<()> {
         }
     };
 
+    // Check for schema version agreement across the cluster
+    if !session.check_schema_agreement().await {
+        eprintln!(
+            "\nWarning: schema version mismatch detected; check the schema versions of your \
+                   nodes in system.local and system.peers.\n"
+        );
+    }
+
     // Determine whether stdin is a pipe/redirect (non-TTY) and --tty hasn't
     // been set to force interactive mode.
     let stdin_is_pipe = !io::stdin().is_terminal() && !config.tty;

--- a/src/session.rs
+++ b/src/session.rs
@@ -94,6 +94,44 @@ impl CqlSession {
         })
     }
 
+    /// Check if all nodes agree on the schema version.
+    /// Returns `true` if schema is in agreement, `false` if there's a mismatch.
+    /// Errors during the check are silently ignored (non-critical).
+    pub async fn check_schema_agreement(&self) -> bool {
+        use std::collections::HashSet;
+
+        let mut versions = HashSet::new();
+
+        // Get local node's schema version
+        if let Ok(result) = self
+            .driver
+            .execute_unpaged("SELECT schema_version FROM system.local WHERE key='local'")
+            .await
+        {
+            for row in &result.rows {
+                if let Some(v) = row.get(0) {
+                    versions.insert(v.to_string());
+                }
+            }
+        }
+
+        // Get peer nodes' schema versions
+        if let Ok(result) = self
+            .driver
+            .execute_unpaged("SELECT schema_version FROM system.peers")
+            .await
+        {
+            for row in &result.rows {
+                if let Some(v) = row.get(0) {
+                    versions.insert(v.to_string());
+                }
+            }
+        }
+
+        // Agreement means exactly 0 or 1 distinct versions
+        versions.len() <= 1
+    }
+
     /// Execute a CQL statement. Handles USE keyspace commands specially.
     pub async fn execute(&mut self, query: &str) -> Result<CqlResult> {
         let trimmed = query.trim();

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -13,5 +13,6 @@ mod describe_tests;
 mod escape_tests;
 mod helpers;
 mod output_tests;
+mod schema_agreement_tests;
 mod ssl_tests;
 mod unicode_tests;

--- a/tests/integration/schema_agreement_tests.rs
+++ b/tests/integration/schema_agreement_tests.rs
@@ -1,0 +1,18 @@
+//! Integration tests for schema version agreement check (PR #113).
+
+use predicates::prelude::*;
+
+use super::helpers::*;
+
+#[test]
+#[ignore = "requires Docker"]
+fn single_node_has_schema_agreement() {
+    let scylla = get_scylla();
+    // A single-node cluster should always have schema agreement.
+    // The warning should NOT appear in stderr for a healthy single node.
+    cqlsh_cmd(scylla)
+        .args(["-e", "SELECT key FROM system.local"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("schema version mismatch").not());
+}


### PR DESCRIPTION
## Summary
- Query `system.local` and `system.peers` for `schema_version` after connecting
- Emit warning to stderr if nodes disagree, matching Python cqlsh behavior
- Warning format: `Warning: schema version mismatch detected; check the schema versions of your nodes in system.local and system.peers.`

Closes #110