### PR TITLE
fix: match Python cqlsh error output format with source prefix and error codes

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,56 @@ pub enum ErrorCategory {
     ConnectionError,
 }
 
+impl ErrorCategory {
+    /// CQL protocol error code for this category.
+    pub fn error_code(&self) -> Option<u32> {
+        match self {
+            Self::ServerError => Some(0x0000),
+            Self::ProtocolError => Some(0x000A),
+            Self::AuthenticationError => Some(0x0100),
+            Self::Unavailable => Some(0x1000),
+            Self::Overloaded => Some(0x1001),
+            Self::IsBootstrapping => Some(0x1002),
+            Self::TruncateError => Some(0x1003),
+            Self::WriteTimeout => Some(0x1100),
+            Self::ReadTimeout => Some(0x1200),
+            Self::ReadFailure => Some(0x1300),
+            Self::FunctionFailure => Some(0x1400),
+            Self::WriteFailure => Some(0x1500),
+            Self::SyntaxException => Some(0x2000),
+            Self::Unauthorized => Some(0x2100),
+            Self::InvalidRequest => Some(0x2200),
+            Self::ConfigurationException => Some(0x2300),
+            Self::AlreadyExists => Some(0x2400),
+            Self::ConnectionError => None,
+        }
+    }
+
+    /// Human-readable category label used in `Error from server` messages.
+    fn server_label(&self) -> &'static str {
+        match self {
+            Self::ServerError => "Server error",
+            Self::ProtocolError => "Protocol error",
+            Self::AuthenticationError => "Bad credentials",
+            Self::Unavailable => "Unavailable exception",
+            Self::Overloaded => "Overloaded",
+            Self::IsBootstrapping => "Is bootstrapping",
+            Self::TruncateError => "Truncate error",
+            Self::WriteTimeout => "Write timeout",
+            Self::ReadTimeout => "Read timeout",
+            Self::ReadFailure => "Read failure",
+            Self::FunctionFailure => "Function failure",
+            Self::WriteFailure => "Write failure",
+            Self::SyntaxException => "Syntax error",
+            Self::Unauthorized => "Unauthorized",
+            Self::InvalidRequest => "Invalid query",
+            Self::ConfigurationException => "Configuration error",
+            Self::AlreadyExists => "Already exists",
+            Self::ConnectionError => "Connection error",
+        }
+    }
+}
+
 impl std::fmt::Display for ErrorCategory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -90,7 +140,16 @@ pub fn classify_error(error: &anyhow::Error) -> ClassifiedError {
 /// Format a classified error for display matching Python cqlsh output.
 pub fn format_error(error: &anyhow::Error) -> String {
     let classified = classify_error(error);
-    format!("{}: {}", classified.category, classified.message)
+    match classified.category.error_code() {
+        Some(code) => format!(
+            "{}: Error from server: code={:04X} [{}] message=\"{}\"",
+            classified.category,
+            code,
+            classified.category.server_label(),
+            classified.message
+        ),
+        None => format!("{}: {}", classified.category, classified.message),
+    }
 }
 
 /// Format a classified error with optional color (red bold when enabled).
@@ -277,7 +336,7 @@ mod tests {
         let exec = ExecutionError::LastAttemptError(attempt);
         let err = anyhow::Error::new(exec);
 
-        assert_eq!(format_error(&err), "SyntaxException: line 1:0 bad input");
+        assert_eq!(format_error(&err), "SyntaxException: Error from server: code=2000 [Syntax error] message=\"line 1:0 bad input\"");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,7 @@ async fn execute_cql_string(
     let mut debug = config.debug;
 
     for stmt in statements {
-        if !execute_single_statement(session, config, colorizer, &mut debug, &stmt).await {
+        if !execute_single_statement(session, config, colorizer, &mut debug, &stmt, None, 0).await {
             had_error = true;
         }
     }
@@ -225,6 +225,8 @@ async fn execute_cql_reader<R: io::BufRead>(
     let mut stmt_parser = StatementParser::new();
     let mut had_error = false;
     let mut debug = config.debug;
+    let mut line_number: usize = 0;
+    let mut stmt_start_line: usize = 1;
 
     for line_result in reader.lines() {
         let line = match line_result {
@@ -234,12 +236,26 @@ async fn execute_cql_reader<R: io::BufRead>(
                 return 1;
             }
         };
+        line_number += 1;
 
-        // Check for shell commands on a fresh line
+        if stmt_parser.is_empty() {
+            stmt_start_line = line_number;
+        }
+
         let trimmed = line.trim();
         if stmt_parser.is_empty() && !trimmed.is_empty() && parser::is_shell_command(trimmed) {
             let clean = trimmed.strip_suffix(';').unwrap_or(trimmed).trim_end();
-            if !execute_single_statement(session, config, colorizer, &mut debug, clean).await {
+            if !execute_single_statement(
+                session,
+                config,
+                colorizer,
+                &mut debug,
+                clean,
+                Some(source_name),
+                stmt_start_line,
+            )
+            .await
+            {
                 had_error = true;
             }
             continue;
@@ -247,10 +263,21 @@ async fn execute_cql_reader<R: io::BufRead>(
 
         if let ParseResult::Complete(statements) = stmt_parser.feed_line(&line) {
             for stmt in statements {
-                if !execute_single_statement(session, config, colorizer, &mut debug, &stmt).await {
+                if !execute_single_statement(
+                    session,
+                    config,
+                    colorizer,
+                    &mut debug,
+                    &stmt,
+                    Some(source_name),
+                    stmt_start_line,
+                )
+                .await
+                {
                     had_error = true;
                 }
             }
+            stmt_start_line = line_number + 1;
         }
     }
 
@@ -273,6 +300,8 @@ fn execute_single_statement<'a>(
     colorizer: &'a CqlColorizer,
     debug: &'a mut bool,
     input: &'a str,
+    source_name: Option<&'a str>,
+    line_number: usize,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + 'a>> {
     Box::pin(async move {
         let trimmed = input.trim();
@@ -408,6 +437,8 @@ fn execute_single_statement<'a>(
             let source_name = expanded.display().to_string();
             let mut stmt_parser = StatementParser::new();
             let mut had_error = false;
+            let mut src_line_number: usize = 0;
+            let mut src_stmt_start: usize = 1;
             for line_result in reader.lines() {
                 let line: String = match line_result {
                     Ok(l) => l,
@@ -416,24 +447,48 @@ fn execute_single_statement<'a>(
                         return false;
                     }
                 };
+                src_line_number += 1;
+                if stmt_parser.is_empty() {
+                    src_stmt_start = src_line_number;
+                }
                 let ltrimmed = line.trim();
                 if stmt_parser.is_empty()
                     && !ltrimmed.is_empty()
                     && parser::is_shell_command(ltrimmed)
                 {
                     let clean = ltrimmed.strip_suffix(';').unwrap_or(ltrimmed).trim_end();
-                    if !execute_single_statement(session, config, colorizer, debug, clean).await {
+                    if !execute_single_statement(
+                        session,
+                        config,
+                        colorizer,
+                        debug,
+                        clean,
+                        Some(&source_name),
+                        src_stmt_start,
+                    )
+                    .await
+                    {
                         had_error = true;
                     }
                     continue;
                 }
                 if let ParseResult::Complete(statements) = stmt_parser.feed_line(&line) {
                     for stmt in statements {
-                        if !execute_single_statement(session, config, colorizer, debug, &stmt).await
+                        if !execute_single_statement(
+                            session,
+                            config,
+                            colorizer,
+                            debug,
+                            &stmt,
+                            Some(&source_name),
+                            src_stmt_start,
+                        )
+                        .await
                         {
                             had_error = true;
                         }
                     }
+                    src_stmt_start = src_line_number + 1;
                 }
             }
             return !had_error;
@@ -562,7 +617,12 @@ fn execute_single_statement<'a>(
                 true
             }
             Err(e) => {
-                eprintln!("{}", error::format_error_colored(&e, colorizer));
+                let err_msg = error::format_error_colored(&e, colorizer);
+                if let Some(src) = source_name {
+                    eprintln!("{src}:{line_number}:{err_msg}");
+                } else {
+                    eprintln!("{err_msg}");
+                }
                 if *debug {
                     eprintln!("Debug: {e:?}");
                 }

--- a/tests/snapshots/output_snapshots__snapshot_error_fallback.snap
+++ b/tests/snapshots/output_snapshots__snapshot_error_fallback.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/output_snapshots.rs
-assertion_line: 217
 expression: format_error(&err)
 ---
-ServerError: table foo does not exist
+ServerError: Error from server: code=0000 [Server error] message="table foo does not exist"

--- a/tests/snapshots/output_snapshots__snapshot_error_invalid_request.snap
+++ b/tests/snapshots/output_snapshots__snapshot_error_invalid_request.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/output_snapshots.rs
-assertion_line: 199
 expression: format_error(&err)
 ---
-InvalidRequest: unconfigured table no_such_table
+InvalidRequest: Error from server: code=2200 [Invalid query] message="unconfigured table no_such_table"

--- a/tests/snapshots/output_snapshots__snapshot_error_syntax_exception.snap
+++ b/tests/snapshots/output_snapshots__snapshot_error_syntax_exception.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/output_snapshots.rs
-assertion_line: 187
 expression: format_error(&err)
 ---
-SyntaxException: line 1:0 no viable alternative at input 'SELEC'
+SyntaxException: Error from server: code=2000 [Syntax error] message="line 1:0 no viable alternative at input 'SELEC'"

--- a/tests/snapshots/output_snapshots__snapshot_error_unauthorized.snap
+++ b/tests/snapshots/output_snapshots__snapshot_error_unauthorized.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/output_snapshots.rs
-assertion_line: 211
 expression: format_error(&err)
 ---
-Unauthorized: User anonymous has no SELECT permission on table system.users
+Unauthorized: Error from server: code=2100 [Unauthorized] message="User anonymous has no SELECT permission on table system.users"


### PR DESCRIPTION
## Summary
- Add `Error from server: code=NNNN [category] message="..."` wrapper to server error messages, matching the Python cassandra-driver's error string format
- Add `<source>:N:` line number prefix to errors in batch/file mode (stdin pipe, `-f` flag, `SOURCE` command), matching Python cqlsh's `show_line_nums` behavior
- Add `ErrorCategory::error_code()` mapping CQL protocol error codes to each category
- No prefix in interactive REPL mode (matches Python cqlsh)

### Example output (batch mode)
```
<stdin>:2:InvalidRequest: Error from server: code=2200 [Invalid query] message="PRIMARY KEY column \"b\" cannot be restricted..."
```

Closes #109