### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/scylladb/cqlsh-rs/compare/v0.3.1...v0.3.2) - 2026-04-20
+
+### Fixed
+
+- match Python cqlsh error output format with source prefix and error codes
+
 ## [0.3.1](https://github.com/scylladb/cqlsh-rs/compare/v0.3.0...v0.3.1) - 2026-04-20
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/scylladb/cqlsh-rs/compare/v0.3.1...v0.3.2) - 2026-04-20

### Fixed

- match Python cqlsh error output format with source prefix and error codes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).