### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/scylladb/cqlsh-rs/compare/v0.3.2...v0.4.0) - 2026-04-20
+
+### Added
+
+- *(SP20)* grammar-aware tab completion with statement-type contexts
+- warn on schema version mismatch after connect
+
+### Fixed
+
+- handle LOGIN command in non-interactive mode
+
+### Other
+
+- *(coverage)* collect coverage from all integration test variants
+- *(SP20)* add grammar-aware completion implementation plan
+
 ## [0.3.2](https://github.com/scylladb/cqlsh-rs/compare/v0.3.1...v0.3.2) - 2026-04-20
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.3.2 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `cqlsh-rs` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field TableMetadata.clustering_order in /tmp/.tmp52la8K/cqlsh-rs/src/driver/mod.rs:87
  field TableMetadata.properties in /tmp/.tmp52la8K/cqlsh-rs/src/driver/mod.rs:89

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant GrammarContext::General 15 -> 27 in /tmp/.tmp52la8K/cqlsh-rs/src/cql_lexer.rs:118

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant GrammarContext:ExpectCreateTarget in /tmp/.tmp52la8K/cqlsh-rs/src/cql_lexer.rs:94
  variant GrammarContext:ExpectAlterTarget in /tmp/.tmp52la8K/cqlsh-rs/src/cql_lexer.rs:96
  variant GrammarContext:ExpectDropTarget in /tmp/.tmp52la8K/cqlsh-rs/src/cql_lexer.rs:98
  variant GrammarContext:ExpectDeleteTarget in /tmp/.tmp52la8K/cqlsh-rs/src/cql_lexer.rs:100
  variant GrammarContext:ExpectGrantRevoke in /tmp/.tmp52la8K/cqlsh-rs/src/cql_lexer.rs:102
  variant GrammarContext:ExpectInsertTarget in /tmp/.tmp52la8K/cqlsh-rs/src/cql_lexer.rs:104
  variant GrammarContext:ExpectBeginTarget in /tmp/.tmp52la8K/cqlsh-rs/src/cql_lexer.rs:106
  variant GrammarContext:ExpectSelectPostFrom in /tmp/.tmp52la8K/cqlsh-rs/src/cql_lexer.rs:108
  variant GrammarContext:ExpectInsertPostValues in /tmp/.tmp52la8K/cqlsh-rs/src/cql_lexer.rs:110
  variant GrammarContext:ExpectDeletePostFrom in /tmp/.tmp52la8K/cqlsh-rs/src/cql_lexer.rs:112
  variant GrammarContext:ExpectUpdateClause in /tmp/.tmp52la8K/cqlsh-rs/src/cql_lexer.rs:114
  variant GrammarContext:ExpectUpdatePostSet in /tmp/.tmp52la8K/cqlsh-rs/src/cql_lexer.rs:116

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  cqlsh_rs::cql_lexer::context_from_tokens now takes 2 parameters instead of 1, in /tmp/.tmp52la8K/cqlsh-rs/src/cql_lexer.rs:617
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/scylladb/cqlsh-rs/compare/v0.3.2...v0.4.0) - 2026-04-20

### Added

- *(SP20)* grammar-aware tab completion with statement-type contexts
- warn on schema version mismatch after connect

### Fixed

- handle LOGIN command in non-interactive mode

### Other

- *(coverage)* collect coverage from all integration test variants
- *(SP20)* add grammar-aware completion implementation plan
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).