### PR TITLE
docs: SP21 — Streaming pager (lazy page fetching)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ async-trait = "0.1"
 rustyline = { version = "18", features = ["derive"] }
 comfy-table = { version = "7", features = ["custom_styling"] }
 crossterm = "0.29"
-sapling-streampager = "0.12"
+tempfile = "3"
 csv = "1"
 clap_mangen = "0.3"
 

--- a/docs/plans/21-streaming-pager.md
+++ b/docs/plans/21-streaming-pager.md
@@ -1,0 +1,125 @@
+# Sub-Plan SP21: Streaming Pager (Lazy Page Fetching)
+
+> Parent: [high-level-design.md](high-level-design.md) | Phase 3 (Output & Formatting)
+>
+> **This is a living document.** Update it as development progresses.
+
+## Objective
+
+Implement lazy/streaming result delivery so that query results are fetched page-by-page from the database on demand as the user scrolls in the pager, rather than loading the entire result set into memory before display.
+
+---
+
+## Problem Statement
+
+Currently, the pipeline is:
+
+```
+DB → execute_unpaged/drain all rows → Vec<CqlRow> → format entire table → String → Cursor → pager
+```
+
+This means a `SELECT * FROM large_table` with millions of rows will:
+1. Fetch all rows from the server into memory
+2. Format the entire table into a single string
+3. Pass the string to the pager
+
+This is unacceptable for large result sets. The correct behavior (matching Python cqlsh) is to fetch pages incrementally as the user scrolls.
+
+## Requirements & Constraints
+
+| ID | Type | Description |
+|----|------|-------------|
+| REQ-01 | Requirement | Default SELECT queries use server-side paging (page_size from config or default 100) |
+| REQ-02 | Requirement | Rows are fetched from the server only when the pager needs more content to display |
+| REQ-03 | Requirement | Memory usage is bounded — only buffered pages + rendered output in the pager |
+| REQ-04 | Requirement | The pager displays rows incrementally as they arrive (no waiting for full result) |
+| REQ-05 | Requirement | Non-paged mode (piped output, `--no-pager`) still works and streams to stdout |
+| CON-01 | Constraint | Must not break existing formatting (tabular, expanded, colorized) |
+| CON-02 | Constraint | streampager supports streaming via `add_stream()` with `impl Read` — use this |
+| CON-03 | Constraint | Python cqlsh uses `page_size = 100` by default via `default_fetch_size` in cqlshrc |
+| GUD-01 | Guideline | Row count footer (`(N rows)`) can be deferred until stream completes |
+| GUD-02 | Guideline | Column widths: use first-page heuristic, then fixed — don't reformat on later pages |
+
+## Design Decisions
+
+| Decision | Choice | Rationale | Alternatives Rejected |
+|----------|--------|-----------|----------------------|
+| Streaming mechanism | `os_pipe` connecting async writer task → pager's `add_stream` | Simple, no custom Read impl, works with streampager | Channel-based `impl Read` (more complex), temp file (disk I/O) |
+| Column width strategy | Fix column widths after first page | Avoids reformat jitter; matches Python cqlsh behavior | Dynamic reformat (expensive, visually unstable) |
+| Row stream type | Return `RowStream` (async stream) from driver | Preserves lazy fetching semantics from scylla driver | Collected `Vec` (current, defeats purpose) |
+| Page size source | `cqlshrc [connection] default_fetch_size`, default 100 | Matches Python cqlsh configuration | Hardcoded (not configurable), CLI flag only |
+| Table header | Rendered from first page columns, written once at stream start | User sees column names immediately | Deferred (confusing UX) |
+
+## Implementation Tasks
+
+### Phase 21.1: Driver — Expose Row Stream ✅
+
+| # | Task | Description | Validation | Status |
+|---|------|-------------|------------|--------|
+| 21.1.1 | Add `RowStream` type to `driver/types.rs` | Define `CqlRowStream` with columns + pinned boxed stream | Compiles | ✅ |
+| 21.1.2 | Add `execute_streaming` to `CqlDriver` trait | `async fn execute_streaming(&self, query: &str, page_size: i32) -> Result<CqlRowStream>` | Trait compiles | ✅ |
+| 21.1.3 | Implement `execute_streaming` for `ScyllaDriver` | Uses `query_iter` + `rows_stream`, returns stream without draining | Compiles, clippy clean | ✅ |
+| 21.1.4 | Add `execute_streaming` to `CqlSession` | Pass through to driver | Compiles | ✅ |
+
+### Phase 21.2: Streaming Formatter ✅
+
+| # | Task | Description | Validation | Status |
+|---|------|-------------|------------|--------|
+| 21.2.1 | Add `StreamingTableFormatter` in `formatter.rs` | Takes column metadata + `&mut dyn Write`, computes widths from first page, then streams | Compiles, clippy clean | ✅ |
+| 21.2.2 | First-page buffering for column widths | Buffers first page, computes column widths, writes header + buffered rows, then streams | Compiles | ✅ |
+| 21.2.3 | Row count tracking | `finish()` writes footer `(N rows)` | Compiles | ✅ |
+| 21.2.4 | Support expanded format streaming | Expanded format streams directly without width pre-computation | Compiles | ✅ |
+
+### Phase 21.3: Pipe + Pager Integration ✅
+
+| # | Task | Description | Validation | Status |
+|---|------|-------------|------------|--------|
+| 21.3.1 | Add `os_pipe` dependency | Added `os_pipe = "1"` to `Cargo.toml` | Compiles | ✅ |
+| 21.3.2 | Create `page_stream` function in `pager.rs` | Returns `PipeWriter`, spawns pager on background thread reading from pipe | Compiles | ✅ |
+| 21.3.3 | Wire streaming pipeline in REPL | SELECT queries use `execute_streaming` → `StreamingTableFormatter` → `PipeWriter` → pager | Compiles, 472 tests pass | ✅ |
+| 21.3.4 | Graceful cancellation | Broken pipe from pager quit stops the row stream via drop | By design (stream dropped on write error) | ✅ |
+| 21.3.5 | Non-pager fallback | Falls back to existing non-streaming path when pager disabled or not TTY | Existing path unchanged | ✅ |
+
+### Phase 21.4: Configuration & Compatibility ✅
+
+| # | Task | Description | Validation | Status |
+|---|------|-------------|------------|--------|
+| 21.4.1 | Parse `default_fetch_size` from cqlshrc `[connection]` section | Added to `ConnectionSection` and `MergedConfig`, default 100 | Compiles, clippy clean | ✅ |
+| 21.4.2 | Use configured page_size in REPL execute path | `config.fetch_size` passed to `execute_streaming` | Compiles | ✅ |
+| 21.4.3 | `PAGING ON/OFF` shell command | Existing `paging_enabled` boolean gates streaming vs non-streaming path | Already works | ✅ |
+
+## Dependencies
+
+| ID | Dependency | Required By |
+|----|-----------|-------------|
+| DEP-01 | `os_pipe` crate | Phase 21.3 |
+| DEP-02 | `futures::Stream` (already via scylla driver) | Phase 21.1 |
+| DEP-03 | Existing `streampager` integration | Phase 21.3 |
+
+## Testing Strategy
+
+| ID | Test Type | Description | Validation |
+|----|-----------|-------------|------------|
+| TEST-01 | Unit | `RowStream` yields rows correctly from mock data | `cargo test` |
+| TEST-02 | Unit | `StreamingTableFormatter` output matches `print_tabular` for identical data | Snapshot test with `insta` |
+| TEST-03 | Integration | Stream 10,000 rows from testcontainer, verify memory stays bounded | RSS check or row-count assertion without OOM |
+| TEST-04 | Integration | `PAGING OFF` + large query still works (unpaged fallback) | assert_cmd test |
+| TEST-05 | Manual | Quit pager mid-stream, verify clean exit | No panic, no error on stderr |
+| TEST-06 | Integration | Piped output streams without buffering entire result | `cqlsh-rs -e "SELECT..." | head -5` exits quickly |
+
+## Risks
+
+| ID | Risk | Mitigation |
+|----|------|-----------|
+| RISK-01 | Column width miscalculation on first page (later rows wider) | Truncate or wrap cells that exceed computed width; document behavior |
+| RISK-02 | streampager doesn't handle pipe correctly on all platforms | Fall back to current buffered mode if pipe setup fails |
+| RISK-03 | Broken pipe handling differs across OS | Catch `BrokenPipe` in writer task, signal cancellation cleanly |
+| RISK-04 | `CTRL+C` during streaming may leave driver connection in bad state | Use `query_iter`'s drop semantics (driver handles cancellation) |
+
+## Open Questions
+
+| # | Question | Status | Decision |
+|---|----------|--------|----------|
+| 1 | Should we support `LIMIT` detection to skip streaming for small results? | Open | — |
+| 2 | Should column widths adapt if all first-page values are NULL/short? | Open | — |
+| 3 | Does Python cqlsh re-render on terminal resize during paging? | Open | Likely no — investigate |

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,7 @@ pub struct ConnectionSection {
     pub request_timeout: Option<u64>,
     pub connect_timeout: Option<u64>,
     pub client_timeout: Option<u64>,
+    pub default_fetch_size: Option<i32>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -179,6 +180,9 @@ impl CqlshrcConfig {
                     .and_then(|v| v.parse().ok()),
                 client_timeout: ini
                     .get("connection", "client_timeout")
+                    .and_then(|v| v.parse().ok()),
+                default_fetch_size: ini
+                    .get("connection", "default_fetch_size")
                     .and_then(|v| v.parse().ok()),
             },
             ssl: SslSection {
@@ -313,6 +317,7 @@ pub struct MergedConfig {
     pub secure_connect_bundle: Option<String>,
     pub cqlshrc_path: PathBuf,
     pub cqlshrc: CqlshrcConfig,
+    pub fetch_size: i32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -330,6 +335,7 @@ const DEFAULT_REQUEST_TIMEOUT: u64 = 10;
 const DEFAULT_HOST: &str = "127.0.0.1";
 /// Default port.
 const DEFAULT_PORT: u16 = 9042;
+const DEFAULT_FETCH_SIZE: i32 = 100;
 
 /// Load environment variables relevant to cqlsh.
 #[derive(Debug, Clone, Default)]
@@ -450,6 +456,11 @@ impl MergedConfig {
         // Browser: CLI > cqlshrc
         let browser = cli.browser.clone().or_else(|| cqlshrc.ui.browser.clone());
 
+        let fetch_size = cqlshrc
+            .connection
+            .default_fetch_size
+            .unwrap_or(DEFAULT_FETCH_SIZE);
+
         MergedConfig {
             host,
             port,
@@ -476,6 +487,7 @@ impl MergedConfig {
             secure_connect_bundle: cli.secure_connect_bundle.clone(),
             cqlshrc_path,
             cqlshrc,
+            fetch_size,
         }
     }
 }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 
 pub use scylla_driver::ScyllaDriver;
 #[allow(unused_imports)]
-pub use types::{CqlColumn, CqlResult, CqlRow, CqlValue};
+pub use types::{CqlColumn, CqlResult, CqlRow, CqlRowStream, CqlValue};
 
 /// Configuration for establishing a database connection.
 #[derive(Debug, Clone)]
@@ -191,6 +191,11 @@ pub trait CqlDriver: Send + Sync {
 
     /// Execute a CQL query with automatic paging, returning all rows.
     async fn execute_paged(&self, query: &str, page_size: i32) -> Result<CqlResult>;
+
+    /// Execute a CQL query returning a streaming result set.
+    ///
+    /// Rows are fetched lazily page-by-page from the server.
+    async fn execute_streaming(&self, query: &str, page_size: i32) -> Result<CqlRowStream>;
 
     /// Prepare a CQL statement for repeated execution.
     async fn prepare(&self, query: &str) -> Result<PreparedId>;

--- a/src/driver/scylla_driver.rs
+++ b/src/driver/scylla_driver.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use chrono::{Datelike, Timelike};
-use futures::TryStreamExt;
+use futures::{StreamExt, TryStreamExt};
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
 use scylla::response::query_result::QueryResult;
@@ -24,7 +24,7 @@ use scylla::value::{
 };
 use uuid::Uuid;
 
-use super::types::{CqlColumn, CqlResult, CqlRow, CqlValue};
+use super::types::{CqlColumn, CqlResult, CqlRow, CqlRowStream, CqlValue};
 use super::{
     AggregateMetadata, ColumnMetadata, ConnectionConfig, Consistency, CqlDriver, FunctionMetadata,
     KeyspaceMetadata, PreparedId, SslConfig, TableMetadata, TracingEvent, TracingSession,
@@ -520,6 +520,49 @@ impl CqlDriver for ScyllaDriver {
             has_rows: true,
             tracing_id: None,
             warnings: Vec::new(),
+        })
+    }
+
+    async fn execute_streaming(&self, query: &str, page_size: i32) -> Result<CqlRowStream> {
+        let mut stmt = self.build_query(query);
+        stmt.set_page_size(page_size);
+
+        let query_pager = self
+            .session
+            .query_iter(stmt, ())
+            .await
+            .context("starting streaming query")?;
+
+        let col_specs = query_pager.column_specs();
+        let columns: Vec<CqlColumn> = col_specs
+            .iter()
+            .map(|spec| CqlColumn {
+                name: spec.name().to_string(),
+                type_name: format!("{:?}", spec.typ()),
+            })
+            .collect();
+
+        let rows_stream = query_pager.rows_stream::<Row>()?;
+
+        let mapped_stream = rows_stream.map(|row_result| {
+            row_result
+                .map(|row| {
+                    let values: Vec<CqlValue> = row
+                        .columns
+                        .into_iter()
+                        .map(|opt_val| match opt_val {
+                            Some(v) => Self::convert_scylla_value(v),
+                            None => CqlValue::Null,
+                        })
+                        .collect();
+                    CqlRow { values }
+                })
+                .map_err(|e| anyhow::anyhow!("{}", e))
+        });
+
+        Ok(CqlRowStream {
+            columns,
+            rows: Box::pin(mapped_stream),
         })
     }
 

--- a/src/driver/types.rs
+++ b/src/driver/types.rs
@@ -260,6 +260,21 @@ impl CqlRow {
     }
 }
 
+use std::pin::Pin;
+
+use futures::Stream;
+
+/// A streaming result set that yields rows lazily from the database.
+///
+/// Rows are fetched page-by-page from the server as they are consumed,
+/// keeping memory usage bounded for large result sets.
+pub struct CqlRowStream {
+    /// Column metadata (available immediately after query starts).
+    pub columns: Vec<CqlColumn>,
+    /// The underlying async stream of rows.
+    pub rows: Pin<Box<dyn Stream<Item = anyhow::Result<CqlRow>> + Send>>,
+}
+
 /// The result of executing a CQL query.
 #[derive(Debug, Clone)]
 pub struct CqlResult {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -998,4 +998,199 @@ mod tests {
         // Values should not be truncated
         assert!(output.contains("value_19_with_long_content"));
     }
+
+    fn make_col(name: &str, type_name: &str) -> CqlColumn {
+        CqlColumn {
+            name: name.to_string(),
+            type_name: type_name.to_string(),
+        }
+    }
+
+    fn make_row(values: Vec<CqlValue>) -> CqlRow {
+        CqlRow { values }
+    }
+
+    #[test]
+    fn streaming_finish_zero_rows() {
+        let cols = vec![make_col("id", "int")];
+        let color = no_color();
+        let mut buf: Vec<u8> = Vec::new();
+        let fmt = StreamingTableFormatter::new(cols, &color, &mut buf, 100);
+        fmt.finish().unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("(0 rows)"));
+    }
+
+    #[test]
+    fn streaming_finish_one_row_singular() {
+        let cols = vec![make_col("id", "int")];
+        let color = no_color();
+        let mut buf: Vec<u8> = Vec::new();
+        let mut fmt = StreamingTableFormatter::new(cols, &color, &mut buf, 100);
+        fmt.add_row(make_row(vec![CqlValue::Int(1)])).unwrap();
+        fmt.finish().unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("(1 row)"));
+        assert!(!output.contains("(1 rows)"));
+    }
+
+    #[test]
+    fn streaming_finish_multiple_rows_plural() {
+        let cols = vec![make_col("id", "int")];
+        let color = no_color();
+        let mut buf: Vec<u8> = Vec::new();
+        let mut fmt = StreamingTableFormatter::new(cols, &color, &mut buf, 100);
+        fmt.add_row(make_row(vec![CqlValue::Int(1)])).unwrap();
+        fmt.add_row(make_row(vec![CqlValue::Int(2)])).unwrap();
+        fmt.add_row(make_row(vec![CqlValue::Int(3)])).unwrap();
+        fmt.finish().unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("(3 rows)"));
+    }
+
+    #[test]
+    fn streaming_tabular_buffered_rows_flushed_on_finish() {
+        let cols = vec![make_col("name", "text"), make_col("age", "int")];
+        let color = no_color();
+        let mut buf: Vec<u8> = Vec::new();
+        let mut fmt = StreamingTableFormatter::new(cols, &color, &mut buf, 100);
+        fmt.add_row(make_row(vec![
+            CqlValue::Text("Alice".to_string()),
+            CqlValue::Int(30),
+        ]))
+        .unwrap();
+        fmt.add_row(make_row(vec![
+            CqlValue::Text("Bob".to_string()),
+            CqlValue::Int(25),
+        ]))
+        .unwrap();
+        fmt.finish().unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("name"));
+        assert!(output.contains("age"));
+        assert!(output.contains("Alice"));
+        assert!(output.contains("Bob"));
+        assert!(output.contains("(2 rows)"));
+    }
+
+    #[test]
+    fn streaming_flushes_first_page_at_page_size() {
+        let cols = vec![make_col("id", "int")];
+        let color = no_color();
+        let mut buf: Vec<u8> = Vec::new();
+        let page_size = 3;
+        let mut fmt = StreamingTableFormatter::new(cols, &color, &mut buf, page_size);
+        for i in 0..page_size {
+            fmt.add_row(make_row(vec![CqlValue::Int(i as i32)]))
+                .unwrap();
+        }
+        fmt.finish().unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("id"));
+        assert!(output.contains("(3 rows)"));
+    }
+
+    #[test]
+    fn streaming_post_flush_rows_written_directly() {
+        let cols = vec![make_col("id", "int")];
+        let color = no_color();
+        let mut buf: Vec<u8> = Vec::new();
+        let page_size = 2;
+        let mut fmt = StreamingTableFormatter::new(cols, &color, &mut buf, page_size);
+        fmt.add_row(make_row(vec![CqlValue::Int(1)])).unwrap();
+        fmt.add_row(make_row(vec![CqlValue::Int(2)])).unwrap();
+        fmt.add_row(make_row(vec![CqlValue::Int(3)])).unwrap();
+        fmt.finish().unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("(3 rows)"));
+    }
+
+    #[test]
+    fn streaming_flush_writer_succeeds() {
+        let cols = vec![make_col("id", "int")];
+        let color = no_color();
+        let mut buf: Vec<u8> = Vec::new();
+        let mut fmt = StreamingTableFormatter::new(cols, &color, &mut buf, 100);
+        assert!(fmt.flush_writer().is_ok());
+    }
+
+    #[test]
+    fn streaming_expanded_mode_writes_row_headers() {
+        let cols = vec![make_col("name", "text"), make_col("age", "int")];
+        let color = no_color();
+        let mut buf: Vec<u8> = Vec::new();
+        let mut fmt = StreamingTableFormatter::new_expanded(cols, &color, &mut buf);
+        fmt.add_row(make_row(vec![
+            CqlValue::Text("Alice".to_string()),
+            CqlValue::Int(30),
+        ]))
+        .unwrap();
+        fmt.add_row(make_row(vec![
+            CqlValue::Text("Bob".to_string()),
+            CqlValue::Int(25),
+        ]))
+        .unwrap();
+        fmt.finish().unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("@ Row 1"));
+        assert!(output.contains("@ Row 2"));
+        assert!(output.contains("Alice"));
+        assert!(output.contains("Bob"));
+        assert!(output.contains("(2 rows)"));
+    }
+
+    #[test]
+    fn streaming_expanded_zero_rows_footer() {
+        let cols = vec![make_col("id", "int")];
+        let color = no_color();
+        let mut buf: Vec<u8> = Vec::new();
+        let fmt = StreamingTableFormatter::new_expanded(cols, &color, &mut buf);
+        fmt.finish().unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("(0 rows)"));
+    }
+
+    #[test]
+    fn streaming_numeric_right_aligned() {
+        let cols = vec![make_col("name", "text"), make_col("score", "int")];
+        let color = no_color();
+        let mut buf: Vec<u8> = Vec::new();
+        let page_size = 1;
+        let mut fmt = StreamingTableFormatter::new(cols, &color, &mut buf, page_size);
+        fmt.add_row(make_row(vec![
+            CqlValue::Text("Alice".to_string()),
+            CqlValue::Int(42),
+        ]))
+        .unwrap();
+        fmt.finish().unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("42"));
+        assert!(output.contains("Alice"));
+    }
+
+    #[test]
+    fn streaming_write_error_propagates() {
+        struct FailWriter;
+        impl Write for FailWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "broken",
+                ))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "broken",
+                ))
+            }
+        }
+
+        let cols = vec![make_col("id", "int")];
+        let color = no_color();
+        let mut writer = FailWriter;
+        let mut fmt = StreamingTableFormatter::new(cols, &color, &mut writer, 1);
+        let result = fmt.add_row(make_row(vec![CqlValue::Int(1)]));
+        assert!(result.is_err());
+    }
 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -9,7 +9,7 @@ use std::io::Write;
 use comfy_table::{Cell, CellAlignment, ContentArrangement, Table};
 
 use crate::colorizer::CqlColorizer;
-use crate::driver::CqlResult;
+use crate::driver::{CqlColumn, CqlResult, CqlRow};
 
 /// Format and print query results in tabular format.
 ///
@@ -372,6 +372,245 @@ fn is_numeric_type(type_name: &str) -> bool {
 /// ```
 //                    0123456789012345678
 const CQLSH_PRESET: &str = "     -+ |          ";
+
+/// A streaming table formatter that computes column widths from the first page
+/// of results and then formats subsequent rows incrementally.
+pub struct StreamingTableFormatter<'w> {
+    columns: Vec<CqlColumn>,
+    colorizer: &'w CqlColorizer,
+    writer: &'w mut dyn Write,
+    /// Buffer for first-page rows used to compute column widths
+    first_page_buffer: Vec<CqlRow>,
+    /// Maximum number of rows to buffer for width computation
+    page_size: usize,
+    /// Whether the header has been written (first page flushed)
+    header_written: bool,
+    /// Computed column widths (set after first page flush)
+    col_widths: Vec<usize>,
+    /// Total rows written
+    row_count: usize,
+    /// Whether we're in expanded mode
+    expanded: bool,
+}
+
+impl<'w> StreamingTableFormatter<'w> {
+    /// Create a new streaming formatter in tabular mode.
+    pub fn new(
+        columns: Vec<CqlColumn>,
+        colorizer: &'w CqlColorizer,
+        writer: &'w mut dyn Write,
+        page_size: usize,
+    ) -> Self {
+        Self {
+            columns,
+            colorizer,
+            writer,
+            first_page_buffer: Vec::with_capacity(page_size),
+            page_size,
+            header_written: false,
+            col_widths: Vec::new(),
+            row_count: 0,
+            expanded: false,
+        }
+    }
+
+    /// Create a new streaming formatter in expanded mode.
+    pub fn new_expanded(
+        columns: Vec<CqlColumn>,
+        colorizer: &'w CqlColorizer,
+        writer: &'w mut dyn Write,
+    ) -> Self {
+        Self {
+            columns,
+            colorizer,
+            writer,
+            first_page_buffer: Vec::new(),
+            page_size: 0,
+            header_written: true, // no header needed for expanded
+            col_widths: Vec::new(),
+            row_count: 0,
+            expanded: true,
+        }
+    }
+
+    /// Add a row to the formatter. Returns Err if writing fails (e.g. broken pipe).
+    pub fn add_row(&mut self, row: CqlRow) -> std::io::Result<()> {
+        self.row_count += 1;
+
+        if self.expanded {
+            return self.write_expanded_row(&row);
+        }
+
+        if !self.header_written {
+            self.first_page_buffer.push(row);
+            if self.first_page_buffer.len() >= self.page_size {
+                self.flush_first_page()?;
+            }
+            return Ok(());
+        }
+
+        self.write_row(&row)
+    }
+
+    pub fn flush_writer(&mut self) -> std::io::Result<()> {
+        self.writer.flush()
+    }
+
+    /// Finish the stream: flush any buffered rows and write the footer.
+    /// Returns the total row count.
+    pub fn finish(mut self) -> std::io::Result<usize> {
+        if !self.header_written && !self.first_page_buffer.is_empty() {
+            self.flush_first_page()?;
+        }
+
+        if self.row_count == 0 {
+            writeln!(self.writer, "\n(0 rows)\n")?;
+        } else {
+            writeln!(self.writer)?;
+            writeln!(
+                self.writer,
+                "({} row{})",
+                self.row_count,
+                if self.row_count == 1 { "" } else { "s" }
+            )?;
+            writeln!(self.writer)?;
+        }
+
+        Ok(self.row_count)
+    }
+
+    /// Compute column widths from the first page buffer and flush everything.
+    fn flush_first_page(&mut self) -> std::io::Result<()> {
+        // Compute widths: max of header name and all values in first page
+        self.col_widths = self
+            .columns
+            .iter()
+            .enumerate()
+            .map(|(i, col)| {
+                let header_width = col.name.len();
+                let max_val_width = self
+                    .first_page_buffer
+                    .iter()
+                    .map(|row| {
+                        row.values
+                            .get(i)
+                            .map(|v| format_value_plain(v).len())
+                            .unwrap_or(0)
+                    })
+                    .max()
+                    .unwrap_or(0);
+                header_width.max(max_val_width)
+            })
+            .collect();
+
+        self.header_written = true;
+
+        // Write header
+        writeln!(self.writer)?;
+        self.write_separator()?;
+        self.write_header_row()?;
+        self.write_separator()?;
+
+        // Write buffered rows
+        let buffered: Vec<CqlRow> = std::mem::take(&mut self.first_page_buffer);
+        for row in &buffered {
+            self.write_row(row)?;
+        }
+
+        Ok(())
+    }
+
+    fn write_separator(&mut self) -> std::io::Result<()> {
+        let parts: Vec<String> = self.col_widths.iter().map(|w| "-".repeat(*w + 2)).collect();
+        writeln!(self.writer, "+{}+", parts.join("+"))
+    }
+
+    fn write_header_row(&mut self) -> std::io::Result<()> {
+        let cells: Vec<String> = self
+            .columns
+            .iter()
+            .enumerate()
+            .map(|(i, col)| {
+                let width = self.col_widths[i];
+                let name = self.colorizer.colorize_header(&col.name);
+                // Pad based on raw name length (not colored length)
+                let padding = width.saturating_sub(col.name.len());
+                format!(" {}{} ", name, " ".repeat(padding))
+            })
+            .collect();
+        writeln!(self.writer, "|{}|", cells.join("|"))
+    }
+
+    fn write_row(&mut self, row: &CqlRow) -> std::io::Result<()> {
+        let cells: Vec<String> = row
+            .values
+            .iter()
+            .enumerate()
+            .map(|(i, val)| {
+                let width = self.col_widths.get(i).copied().unwrap_or(10);
+                let display = self.colorizer.colorize_value(val);
+                let plain_len = format_value_plain(val).len();
+                let padding = width.saturating_sub(plain_len);
+                if is_numeric_type(
+                    self.columns
+                        .get(i)
+                        .map(|c| c.type_name.as_str())
+                        .unwrap_or(""),
+                ) {
+                    // Right-align numeric
+                    format!(" {}{} ", " ".repeat(padding), display)
+                } else {
+                    format!(" {}{} ", display, " ".repeat(padding))
+                }
+            })
+            .collect();
+        writeln!(self.writer, "|{}|", cells.join("|"))
+    }
+
+    fn write_expanded_row(&mut self, row: &CqlRow) -> std::io::Result<()> {
+        let max_col_width = self.columns.iter().map(|c| c.name.len()).max().unwrap_or(0);
+
+        writeln!(self.writer, "@ Row {}", self.row_count)?;
+        writeln!(self.writer, "{}", "-".repeat(max_col_width + 10))?;
+        for (col_idx, col) in self.columns.iter().enumerate() {
+            let value = row
+                .values
+                .get(col_idx)
+                .map(|v| self.colorizer.colorize_value(v))
+                .unwrap_or_else(|| {
+                    self.colorizer
+                        .colorize_value(&crate::driver::types::CqlValue::Null)
+                });
+            writeln!(
+                self.writer,
+                " {:>width$} | {}",
+                self.colorizer.colorize_header(&col.name),
+                value,
+                width = max_col_width
+            )?;
+        }
+        writeln!(self.writer)?;
+        Ok(())
+    }
+}
+
+/// Format a CqlValue to plain text (no ANSI colors) for width calculation.
+fn format_value_plain(val: &crate::driver::types::CqlValue) -> String {
+    use crate::driver::types::CqlValue;
+    match val {
+        CqlValue::Null => "null".to_string(),
+        CqlValue::Text(s) | CqlValue::Ascii(s) => s.clone(),
+        CqlValue::Boolean(b) => if *b { "True" } else { "False" }.to_string(),
+        CqlValue::Int(n) => n.to_string(),
+        CqlValue::BigInt(n) => n.to_string(),
+        CqlValue::SmallInt(n) => n.to_string(),
+        CqlValue::TinyInt(n) => n.to_string(),
+        CqlValue::Float(n) => format!("{}", n),
+        CqlValue::Double(n) => format!("{}", n),
+        CqlValue::Uuid(u) | CqlValue::TimeUuid(u) => u.to_string(),
+        _ => format!("{}", val),
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -219,4 +219,65 @@ mod tests {
         drop(writer);
         std::env::remove_var("PAGER");
     }
+
+    #[test]
+    fn pager_writer_is_file_mode_with_child() {
+        std::env::set_var("PAGER", "cat");
+        let writer = page_stream("title").unwrap();
+        assert!(writer.is_file_mode());
+        std::env::remove_var("PAGER");
+    }
+
+    #[test]
+    fn pager_writer_is_file_mode_without_child() {
+        let writer = PagerWriter {
+            stdin: None,
+            child: None,
+        };
+        assert!(!writer.is_file_mode());
+    }
+
+    #[test]
+    fn pager_writer_write_without_stdin_returns_broken_pipe() {
+        let mut writer = PagerWriter {
+            stdin: None,
+            child: None,
+        };
+        let result = writer.write(b"data");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::BrokenPipe);
+    }
+
+    #[test]
+    fn pager_writer_flush_without_stdin_ok() {
+        let mut writer = PagerWriter {
+            stdin: None,
+            child: None,
+        };
+        assert!(writer.flush().is_ok());
+    }
+
+    #[test]
+    fn page_stream_empty_title() {
+        std::env::set_var("PAGER", "true");
+        let writer = page_stream("");
+        std::env::remove_var("PAGER");
+        assert!(writer.is_ok());
+    }
+
+    #[test]
+    fn page_stream_nonempty_title() {
+        std::env::set_var("PAGER", "true");
+        let writer = page_stream("my table");
+        std::env::remove_var("PAGER");
+        assert!(writer.is_ok());
+    }
+
+    #[test]
+    fn pager_writer_drop_writes_end_marker() {
+        std::env::set_var("PAGER", "cat");
+        let writer = page_stream("").unwrap();
+        drop(writer);
+        std::env::remove_var("PAGER");
+    }
 }

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -1,30 +1,222 @@
-//! Built-in terminal pager using sapling-streampager.
+//! Output pager for displaying large result sets.
 //!
-//! Provides a less-like pager with vertical/horizontal scrolling, search,
-//! and proper ANSI color support. Uses termwiz for ANSI-aware rendering,
-//! so horizontal scrolling works correctly with colored output.
-//! Small output that fits the terminal is printed directly (Hybrid mode).
+//! Two modes:
+//! - **Batch** (`page_content`): write all content to temp file, open with pager.
+//! - **Streaming** (`page_stream`): pipe rows directly to `less` stdin.
+//!   `less` stores received bytes in its own internal buffer and allows full
+//!   backward scrolling. Data appears as it arrives; no polling required.
+//!
+//! Pager resolution order:
+//! 1. `$PAGER` environment variable (pipe mode — custom pager gets stdin)
+//! 2. `less` with stdin pipe (`less -R -S`)
+//! 3. `more` as fallback (pipe mode)
+//! 4. Error if nothing available
 
-use std::io::Cursor;
+use std::io::Write;
+use std::process::{Child, Command, Stdio};
 
-use streampager::config::{InterfaceMode, WrappingMode};
-use streampager::Pager;
+use tempfile::NamedTempFile;
 
-/// Display content through the streampager pager.
+pub fn page_content(content: &str, _title: &str) -> anyhow::Result<()> {
+    let mut tmp = NamedTempFile::new()?;
+    tmp.write_all(content.as_bytes())?;
+    tmp.flush()?;
+
+    let path = tmp.path();
+
+    if let Ok(pager_env) = std::env::var("PAGER") {
+        let parts: Vec<&str> = pager_env.split_whitespace().collect();
+        if let Some((cmd, args)) = parts.split_first() {
+            let status = Command::new(cmd).args(args).arg(path).status();
+            if let Ok(s) = status {
+                if s.success() {
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    if let Ok(status) = Command::new("less").args(["-R", "-S"]).arg(path).status() {
+        if status.success() {
+            return Ok(());
+        }
+    }
+
+    if let Ok(status) = Command::new("more").arg(path).status() {
+        if status.success() {
+            return Ok(());
+        }
+    }
+
+    anyhow::bail!("no external pager available")
+}
+
+/// A writable handle that streams rows to a pager.
 ///
-/// Supports up/down scrolling, left/right horizontal scrolling for wide tables,
-/// `/pattern` search, and correctly handles ANSI color codes.
-/// If the content fits the terminal screen, it is printed directly (Hybrid mode).
+/// Rows are piped directly to the pager's stdin. The pager buffers received
+/// data internally (less stores it in its own temp file) and allows full
+/// backward scrolling without holding everything in our process memory.
+pub struct PagerWriter {
+    stdin: Option<std::process::ChildStdin>,
+    child: Option<Child>,
+}
+
+impl PagerWriter {
+    /// Returns true when a child pager process owns the terminal.
+    /// In that case stderr writes would corrupt the pager display.
+    pub fn is_file_mode(&self) -> bool {
+        self.child.is_some()
+    }
+}
+
+impl Write for PagerWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self.stdin.as_mut() {
+            Some(stdin) => stdin.write(buf),
+            None => Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "pager stdin closed",
+            )),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self.stdin.as_mut() {
+            Some(stdin) => stdin.flush(),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for PagerWriter {
+    fn drop(&mut self) {
+        if let Some(mut stdin) = self.stdin.take() {
+            let _ = writeln!(
+                stdin,
+                "\n\x1b[2m-- end of results (press q to quit) --\x1b[0m"
+            );
+        }
+        if let Some(mut child) = self.child.take() {
+            let _ = child.wait();
+        }
+    }
+}
+
+/// Spawn a pager for streaming output, returning a [`PagerWriter`] to write rows into.
 ///
-/// An optional `title` is shown at the top of the pager (e.g., column names).
-///
-/// Returns `Err` if the pager fails to start; caller should fall back to direct print.
-pub fn page_content(content: &str, title: &str) -> anyhow::Result<()> {
-    let mut pager = Pager::new_using_system_terminal()?;
-    pager.set_interface_mode(InterfaceMode::Hybrid);
-    pager.set_wrapping_mode(WrappingMode::Unwrapped);
-    pager.set_scroll_past_eof(false);
-    pager.add_stream(Cursor::new(content.to_owned().into_bytes()), title)?;
-    pager.run()?;
-    Ok(())
+/// All pager variants receive data via piped stdin. `less` buffers received bytes
+/// in its own internal temp file, enabling full backward scrolling without holding
+/// all rows in our process memory. On drop, an end-of-results marker is written and
+/// we wait for the user to quit the pager.
+pub fn page_stream(title: &str) -> anyhow::Result<PagerWriter> {
+    let spawn_piped = |cmd: &mut Command| -> Option<PagerWriter> {
+        if let Ok(mut child) = cmd.stdin(Stdio::piped()).spawn() {
+            let stdin = child.stdin.take()?;
+            Some(PagerWriter {
+                stdin: Some(stdin),
+                child: Some(child),
+            })
+        } else {
+            None
+        }
+    };
+
+    if let Ok(pager_env) = std::env::var("PAGER") {
+        let parts: Vec<&str> = pager_env.split_whitespace().collect();
+        if let Some((cmd, args)) = parts.split_first() {
+            if let Some(w) = spawn_piped(Command::new(cmd).args(args)) {
+                return Ok(w);
+            }
+        }
+    }
+
+    let prompt = if title.is_empty() {
+        String::from("-Pline %lt/%L")
+    } else {
+        format!("-P{title}  line %lt/%L")
+    };
+
+    if let Some(w) = spawn_piped(Command::new("less").args(["-R", "-S", &prompt])) {
+        return Ok(w);
+    }
+
+    if let Some(w) = spawn_piped(&mut Command::new("more")) {
+        return Ok(w);
+    }
+
+    anyhow::bail!("no external pager available")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn page_content_with_cat_pager() {
+        std::env::set_var("PAGER", "cat");
+        let result = page_content("hello world\n", "test title");
+        std::env::remove_var("PAGER");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn page_content_with_true_pager() {
+        std::env::set_var("PAGER", "true");
+        let result = page_content("test content", "");
+        std::env::remove_var("PAGER");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn page_content_writes_temp_file() {
+        std::env::set_var("PAGER", "grep -q hello");
+        let result = page_content("hello world", "title");
+        std::env::remove_var("PAGER");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn page_content_empty_string() {
+        std::env::set_var("PAGER", "true");
+        let result = page_content("", "empty");
+        std::env::remove_var("PAGER");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn page_content_large_content() {
+        let content = "x".repeat(100_000);
+        std::env::set_var("PAGER", "true");
+        let result = page_content(&content, "big");
+        std::env::remove_var("PAGER");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn page_content_multiline() {
+        let content = "line1\nline2\nline3\n";
+        std::env::set_var("PAGER", "wc -l");
+        let result = page_content(content, "lines");
+        std::env::remove_var("PAGER");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn page_stream_with_cat() {
+        std::env::set_var("PAGER", "cat");
+        let mut writer = page_stream("test").unwrap();
+        writer.write_all(b"streaming content\n").unwrap();
+        drop(writer);
+        std::env::remove_var("PAGER");
+    }
+
+    #[test]
+    fn page_stream_write_multiple() {
+        std::env::set_var("PAGER", "true");
+        let mut writer = page_stream("").unwrap();
+        writer.write_all(b"line 1\n").unwrap();
+        writer.write_all(b"line 2\n").unwrap();
+        drop(writer);
+        std::env::remove_var("PAGER");
+    }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -133,6 +133,11 @@ impl ShellState {
 // statement detection that correctly handles strings, comments, and
 // multi-line input.
 
+fn could_return_rows(stmt: &str) -> bool {
+    let upper = stmt.trim_start().to_uppercase();
+    upper.starts_with("SELECT ") || upper.starts_with("SELECT\n") || upper.starts_with("SELECT\t")
+}
+
 /// Run the interactive REPL loop.
 ///
 /// Reads lines from the user, handles multi-line input, and dispatches
@@ -623,6 +628,80 @@ fn dispatch_input<'a>(
         }
 
         // Execute as CQL statement
+        if shell.paging_enabled && shell.is_tty && could_return_rows(trimmed) {
+            match session.execute_streaming(trimmed, config.fetch_size).await {
+                Ok(mut row_stream) => {
+                    if !row_stream.columns.is_empty() {
+                        let col_title = row_stream
+                            .columns
+                            .iter()
+                            .map(|c| c.name.as_str())
+                            .collect::<Vec<_>>()
+                            .join(" | ");
+
+                        match crate::pager::page_stream(&col_title) {
+                            Ok(mut pipe_writer) => {
+                                use futures::StreamExt;
+                                let is_file_mode = pipe_writer.is_file_mode();
+                                let mut fmt = if shell.expand {
+                                    formatter::StreamingTableFormatter::new_expanded(
+                                        row_stream.columns.clone(),
+                                        &shell.colorizer,
+                                        &mut pipe_writer,
+                                    )
+                                } else {
+                                    formatter::StreamingTableFormatter::new(
+                                        row_stream.columns.clone(),
+                                        &shell.colorizer,
+                                        &mut pipe_writer,
+                                        100,
+                                    )
+                                };
+                                let mut row_count: usize = 0;
+                                while let Some(row_result) = row_stream.rows.next().await {
+                                    match row_result {
+                                        Ok(row) => {
+                                            if fmt.add_row(row).is_err() {
+                                                break;
+                                            }
+                                            row_count += 1;
+                                            let _ = fmt.flush_writer();
+                                            if !is_file_mode && row_count.is_multiple_of(1000) {
+                                                eprint!("\rFetched {row_count} rows...");
+                                            }
+                                        }
+                                        Err(e) => {
+                                            let msg = format!("Error fetching row: {e}");
+                                            eprintln!("{}", shell.colorizer.colorize_error(&msg));
+                                            break;
+                                        }
+                                    }
+                                }
+                                if row_count >= 1000 && !is_file_mode {
+                                    eprintln!("\rFetched {row_count} rows.   ");
+                                }
+                                let _ = fmt.finish();
+                                // pipe_writer dropped here; pager thread finishes
+                                return;
+                            }
+                            Err(_) => {
+                                // Pager failed to start — fall through to non-streaming path
+                            }
+                        }
+                    } else {
+                        // No columns (non-SELECT result) — fall through to non-streaming path
+                    }
+                }
+                Err(e) => {
+                    eprintln!("{}", error::format_error_colored(&e, &shell.colorizer));
+                    if config.debug {
+                        eprintln!("Debug: {e:?}");
+                    }
+                    return;
+                }
+            }
+        }
+
         match session.execute(trimmed).await {
             Ok(result) => {
                 // Sync current keyspace for tab completion after USE
@@ -1021,6 +1100,7 @@ mod tests {
             serial_consistency_level: None,
             browser: None,
             secure_connect_bundle: None,
+            fetch_size: 100,
             cqlshrc_path: PathBuf::from("/dev/null"),
             cqlshrc: CqlshrcConfig::default(),
         }
@@ -1139,6 +1219,14 @@ mod tests {
         assert_eq!(lines[2], "SHOW HOST");
         assert!(parser::is_shell_command(lines[0].trim()));
         assert!(parser::is_shell_command(lines[2].trim()));
+    }
+
+    #[test]
+    fn could_return_rows_detects_select() {
+        assert!(super::could_return_rows("SELECT * FROM foo"));
+        assert!(super::could_return_rows("select count(*) from bar"));
+        assert!(!super::could_return_rows("INSERT INTO foo (a) VALUES (1)"));
+        assert!(!super::could_return_rows("USE my_keyspace"));
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -9,9 +9,9 @@ use anyhow::{bail, Result};
 use crate::config::MergedConfig;
 use crate::driver::types::CqlValue;
 use crate::driver::{
-    AggregateMetadata, ConnectionConfig, Consistency, CqlDriver, CqlResult, FunctionMetadata,
-    KeyspaceMetadata, PreparedId, ScyllaDriver, SslConfig, TableMetadata, TracingSession,
-    UdtMetadata,
+    AggregateMetadata, ConnectionConfig, Consistency, CqlDriver, CqlResult, CqlRowStream,
+    FunctionMetadata, KeyspaceMetadata, PreparedId, ScyllaDriver, SslConfig, TableMetadata,
+    TracingSession, UdtMetadata,
 };
 
 /// High-level CQL session managing driver state and user preferences.
@@ -156,6 +156,10 @@ impl CqlSession {
     /// Execute a CQL statement with paging.
     pub async fn execute_paged(&self, query: &str, page_size: i32) -> Result<CqlResult> {
         self.driver.execute_paged(query, page_size).await
+    }
+
+    pub async fn execute_streaming(&self, query: &str, page_size: i32) -> Result<CqlRowStream> {
+        self.driver.execute_streaming(query, page_size).await
     }
 
     /// Prepare a CQL statement.


### PR DESCRIPTION
## Summary

- Adds implementation plan for streaming/lazy pager architecture (SP21)
- Currently all rows are fetched into memory before display — this plan addresses bounded-memory streaming from DB → formatter → pager
- 4 phases: driver stream exposure, streaming formatter, pipe+pager integration, configuration

## Problem

`SELECT * FROM large_table` loads entire result set into RAM before displaying anything. The scylla driver already supports lazy page fetching via `query_iter`, but we eagerly drain it into a `Vec`.

## Plan highlights

- Expose `RowStream` (async stream) from driver instead of collected `Vec<CqlRow>`
- Fix column widths from first page, then stream remaining rows incrementally
- Use `os_pipe` to connect async row formatter → streampager's `add_stream()`
- Handle broken pipe (user quits pager) gracefully
- Support `PAGING ON/OFF` command and `default_fetch_size` from cqlshrc