### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/scylladb/cqlsh-rs/compare/v0.4.0...v0.4.1) - 2026-04-21
+
+### Added
+
+- add Docker Hub publishing for releases and main branch builds
+
+### Fixed
+
+- *(ci)* restore RELEASE_PLZ_TOKEN for release-pr step
+- *(ci)* handle release-plz release-pr 403 error gracefully
+
+### Other
+
+- port 34 Python cqlsh dtest integration tests
+
 ## [0.4.0](https://github.com/scylladb/cqlsh-rs/compare/v0.3.2...v0.4.0) - 2026-04-20
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/scylladb/cqlsh-rs/compare/v0.4.0...v0.4.1) - 2026-04-21

### Added

- add Docker Hub publishing for releases and main branch builds

### Fixed

- *(ci)* restore RELEASE_PLZ_TOKEN for release-pr step
- *(ci)* handle release-plz release-pr 403 error gracefully

### Other

- port 34 Python cqlsh dtest integration tests
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).