### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/scylladb/cqlsh-rs/compare/v0.4.1...v0.4.2) - 2026-04-21
+
+### Fixed
+
+- resolve clippy and rustfmt issues after rebase
+
+### Other
+
+- *(describe)* add unit tests for format_property_value
+- *(completer)* add unit tests for context detection and filtering
+- *(error)* add comprehensive unit tests for error classification
+- *(copy)* add unit tests for CSV formatting edge cases
+- *(colorizer)* add unit tests for collection and warning colorization
+- *(formatter)* add unit tests for JSON formatting and value conversion
+
 ## [0.4.1](https://github.com/scylladb/cqlsh-rs/compare/v0.4.0...v0.4.1) - 2026-04-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.4.1 -> 0.4.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.2](https://github.com/scylladb/cqlsh-rs/compare/v0.4.1...v0.4.2) - 2026-04-21

### Fixed

- resolve clippy and rustfmt issues after rebase

### Other

- *(describe)* add unit tests for format_property_value
- *(completer)* add unit tests for context detection and filtering
- *(error)* add comprehensive unit tests for error classification
- *(copy)* add unit tests for CSV formatting edge cases
- *(colorizer)* add unit tests for collection and warning colorization
- *(formatter)* add unit tests for JSON formatting and value conversion
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).