### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/scylladb/cqlsh-rs/compare/v0.4.2...v0.5.0) - 2026-04-22
+
+### Added
+
+- *(pager)* replace sapling-streampager with pipe-based streaming pager
+
+### Fixed
+
+- remove misleading "Re-run failed jobs" link from CI summary footer
+- update footer text to match renamed workflow
+- update CI summary comment in place when all checks pass
+
+### Other
+
+- *(pager,formatter)* add unit tests for PagerWriter and StreamingTableFormatter
+- add SP21 streaming pager implementation plan
+- consolidate CI summary into single job
+
 ## [0.4.2](https://github.com/scylladb/cqlsh-rs/compare/v0.4.1...v0.4.2) - 2026-04-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.4.2 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `cqlsh-rs` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field MergedConfig.fetch_size in /tmp/.tmpc3vb0L/cqlsh-rs/src/config.rs:320
  field ConnectionSection.default_fetch_size in /tmp/.tmpc3vb0L/cqlsh-rs/src/config.rs:61

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_added.ron

Failed in:
  trait method cqlsh_rs::driver::CqlDriver::execute_streaming in file /tmp/.tmpc3vb0L/cqlsh-rs/src/driver/mod.rs:198
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/scylladb/cqlsh-rs/compare/v0.4.2...v0.5.0) - 2026-04-22

### Added

- *(pager)* replace sapling-streampager with pipe-based streaming pager

### Fixed

- remove misleading "Re-run failed jobs" link from CI summary footer
- update footer text to match renamed workflow
- update CI summary comment in place when all checks pass

### Other

- *(pager,formatter)* add unit tests for PagerWriter and StreamingTableFormatter
- add SP21 streaming pager implementation plan
- consolidate CI summary into single job
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).