### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/scylladb/cqlsh-rs/compare/v0.5.0...v0.5.1) - 2026-04-22
+
+### Fixed
+
+- *(ci)* download only needed artifacts in upload-release-artifacts job
+
 ## [0.5.0](https://github.com/scylladb/cqlsh-rs/compare/v0.4.2...v0.5.0) - 2026-04-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1](https://github.com/scylladb/cqlsh-rs/compare/v0.5.0...v0.5.1) - 2026-04-22

### Fixed

- *(ci)* download only needed artifacts in upload-release-artifacts job
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).