### PR TITLE
docs: implementation plan for Unix domain socket support (SP21)

### DIFF
--- a/docs/plans/21-unix-domain-socket-support.md
+++ b/docs/plans/21-unix-domain-socket-support.md
@@ -1,0 +1,12 @@
+# Sub-Plan SP21: Unix Domain Socket Support
+
+> **This plan has been split into two documents:**
+>
+> - **[SP21a — Short Range (Internal Proxy)](21a-unix-domain-socket-short-range.md)** — Immediate implementation using a built-in TCP-to-UDS proxy. Fully self-contained within cqlsh-rs, no upstream changes needed.
+>
+> - **[SP21b — Long Range (Native Driver UDS)](21b-unix-domain-socket-long-range.md)** — Future migration to native driver UDS support once [scylladb/scylla-rust-driver#1616](https://github.com/scylladb/scylla-rust-driver/issues/1616) is implemented (milestone 1.7.0). Replaces the proxy with direct `SessionBuilder::known_node_unix()`.
+>
+> **Upstream references**:
+> - [scylladb/scylla-cqlsh#67](https://github.com/scylladb/scylla-cqlsh/pull/67) — Python cqlsh UDS support
+> - [scylladb/scylladb#16489](https://github.com/scylladb/scylladb/issues/16489) — ScyllaDB maintenance socket
+> - [scylladb/scylla-rust-driver#1616](https://github.com/scylladb/scylla-rust-driver/issues/1616) — Native driver UDS support request

--- a/docs/plans/21a-unix-domain-socket-short-range.md
+++ b/docs/plans/21a-unix-domain-socket-short-range.md
@@ -1,0 +1,107 @@
+# Sub-Plan SP21a: Unix Domain Socket Support — Short Range (Internal Proxy)
+
+> Parent: [high-level-design.md](high-level-design.md) | Phase: 2 (Driver & Connection)
+>
+> **This is a living document.** Update it as development progresses.
+>
+> **Upstream reference**: [scylladb/scylla-cqlsh#67](https://github.com/scylladb/scylla-cqlsh/pull/67) — "Make cqlsh work with unix domain sockets"
+>
+> **Related**: [SP21b — Long Range (Native Driver UDS)](21b-unix-domain-socket-long-range.md)
+
+## Objective
+
+Enable cqlsh-rs to connect to Cassandra/ScyllaDB via Unix domain sockets (UDS) using a built-in TCP-to-UDS proxy. This is the immediate solution that requires no upstream driver changes.
+
+When the user passes a filesystem path (e.g., `/var/run/scylla/maintenance.sock`) as the hostname, cqlsh-rs detects it is a socket and connects over UDS transparently.
+
+---
+
+## Background
+
+The scylla-rust-driver (as of 2026) does **NOT** support Unix domain sockets natively. The connection layer is hardcoded to TCP. This plan implements a self-contained workaround: an async TCP-to-UDS proxy on localhost that bridges the driver's TCP connection to the actual Unix socket.
+
+See [SP21b](21b-unix-domain-socket-long-range.md) for the long-term plan to use native driver UDS support once [scylla-rust-driver#1616](https://github.com/scylladb/scylla-rust-driver/issues/1616) is implemented.
+
+---
+
+## Requirements & Constraints
+
+| ID | Type | Description |
+|----|------|-------------|
+| REQ-01 | Requirement | When hostname is a Unix socket path, connect over UDS |
+| REQ-02 | Requirement | Auto-detect socket vs hostname (check `stat()` for `S_ISSOCK`) |
+| REQ-03 | Requirement | LOGIN reconnection must preserve UDS mode |
+| REQ-04 | Requirement | Work on Linux and macOS (UDS not available on Windows) |
+| CON-01 | Constraint | scylla-rust-driver has no native UDS support |
+| CON-02 | Constraint | Must not fork or vendor the scylla-rust-driver |
+| GUD-01 | Guideline | Keep the workaround isolated so it can be removed when driver adds UDS support (SP21b) |
+
+---
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| **How to connect over UDS** | Built-in async TCP-to-UDS proxy | Zero external dependencies, transparent to user, self-contained |
+| **Proxy architecture** | Localhost ephemeral-port listener, forwards to UDS | Driver connects to `127.0.0.1:<ephemeral>` as normal TCP; proxy task bridges to `UnixStream` |
+| **Detection logic** | `std::fs::metadata()` + `file_type().is_socket()` on `config.host` | Matches Python cqlsh behavior exactly |
+| **Platform support** | `#[cfg(unix)]` gated | UDS is fundamentally a Unix concept |
+| **Isolation** | All proxy code in `src/driver/uds_proxy.rs` | Easy to remove/replace when native driver UDS lands |
+
+---
+
+## Implementation Tasks
+
+### Phase 1: UDS Detection & Proxy Infrastructure
+
+| # | Task | Description | Validation |
+|---|------|-------------|------------|
+| 1.1 | Add UDS detection utility | Create `fn is_unix_socket(path: &str) -> bool` in `src/driver/mod.rs` that calls `std::fs::metadata(path)` and checks `file_type().is_socket()`. Guard with `#[cfg(unix)]`. On non-unix, return `false`. | Unit test: returns `true` for a created UDS, `false` for regular file, `false` for nonexistent path |
+| 1.2 | Implement TCP-to-UDS proxy | Create `src/driver/uds_proxy.rs`. Implement `async fn start_uds_proxy(socket_path: &str) -> Result<(SocketAddr, JoinHandle<()>)>` that: (a) binds a `TcpListener` on `127.0.0.1:0` (ephemeral port), (b) spawns a Tokio task that accepts TCP connections and bidirectionally copies to/from a `tokio::net::UnixStream` connected to `socket_path`, (c) returns the bound `SocketAddr` and the task handle. | Unit test: proxy forwards data bidirectionally between TCP client and mock UDS server |
+| 1.3 | Wire proxy into `ScyllaDriver::connect()` | In `src/driver/scylla_driver.rs`, before building the `SessionBuilder`, check `is_unix_socket(&config.host)`. If true, call `start_uds_proxy(&config.host)` and use the returned `SocketAddr` as the contact point. Store the `JoinHandle` in `ScyllaDriver` for cleanup on drop. | Integration test: connect to a local ScyllaDB via UDS (if available), or unit test with mock |
+| 1.4 | Update `ConnectionConfig` | Add `pub unix_socket: bool` field to `ConnectionConfig` to track whether UDS mode is active (set during detection). Used by LOGIN reconnection to preserve UDS mode. | Existing tests still compile and pass |
+
+### Phase 2: LOGIN Reconnection & Docs
+
+| # | Task | Description | Validation |
+|---|------|-------------|------------|
+| 2.1 | Preserve UDS mode in LOGIN | In the LOGIN handler, ensure `new_config` preserves the original `host` value (which is the socket path). The detection in `connect()` handles the rest. | Manual test: `LOGIN` command reconnects over UDS when originally connected via UDS |
+| 2.2 | Config documentation | Update `README.md` usage section and `src/cli.rs` help text to document UDS support: "If hostname is a Unix socket path, cqlsh-rs connects over the Unix domain socket." | README includes UDS usage example |
+
+### Phase 3: Testing & Platform Guards
+
+| # | Task | Description | Validation |
+|---|------|-------------|------------|
+| 3.1 | Platform compilation guard | In `src/driver/uds_proxy.rs`, add `#[cfg(not(unix))]` stub that returns an error: "Unix domain sockets are not supported on this platform". | Code review confirms cfg gates are correct |
+| 3.2 | Unit tests for proxy | Test proxy data forwarding: create a UDS listener, start proxy, connect TCP client through proxy, verify bidirectional data transfer. | `cargo test uds_proxy` passes |
+| 3.3 | Unit tests for detection | Test `is_unix_socket()` with: real UDS, regular file, directory, nonexistent path, TCP hostname string. | `cargo test is_unix_socket` passes |
+| 3.4 | Integration test (optional) | If CI has ScyllaDB with maintenance socket enabled, test full connection flow. Otherwise, document manual test procedure. | Test passes in CI or manual test procedure documented |
+
+---
+
+## Dependencies
+
+| ID | Dependency | Required By |
+|----|-----------|-------------|
+| DEP-01 | `tokio::net::UnixStream` / `UnixListener` (tokio, already a dependency) | Task 1.2 |
+| DEP-02 | No new crate dependencies required | All tasks |
+
+---
+
+## Risks
+
+| ID | Risk | Mitigation |
+|----|------|-----------|
+| RISK-01 | Proxy adds latency to every CQL frame | Localhost TCP + UDS copy is sub-millisecond. Maintenance socket is low-throughput admin operations. |
+| RISK-02 | Proxy task leak on disconnect | Store `JoinHandle` in `ScyllaDriver`, abort on drop. Use `tokio::select!` for clean shutdown. |
+| RISK-03 | Driver discovers nodes and tries TCP connections | Disable auto-discovery when in UDS mode, or accept graceful failure for secondary connections. |
+| RISK-04 | File path that exists but is not a socket | Check `S_ISSOCK` explicitly, not just path existence. Matches Python cqlsh behavior. |
+
+---
+
+## Open Questions
+
+| # | Question | Status | Decision |
+|---|----------|--------|----------|
+| 1 | Should we also support `--unix-socket <path>` explicit flag? | Open | Auto-detection matches Python cqlsh behavior; explicit flag could be added later |
+| 2 | How does auto-node-discovery interact with UDS mode? | Open | Likely need to disable topology refresh when in UDS mode |

--- a/docs/plans/21b-unix-domain-socket-long-range.md
+++ b/docs/plans/21b-unix-domain-socket-long-range.md
@@ -1,0 +1,68 @@
+# Sub-Plan SP21b: Unix Domain Socket Support — Long Range (Native Driver UDS)
+
+> Parent: [high-level-design.md](high-level-design.md) | Phase: 2 (Driver & Connection)
+>
+> **This is a living document.** Update it as development progresses.
+>
+> **Depends on**: [scylladb/scylla-rust-driver#1616](https://github.com/scylladb/scylla-rust-driver/issues/1616) — "Feature request: Unix domain socket support"
+>
+> **Replaces**: [SP21a — Short Range (Internal Proxy)](21a-unix-domain-socket-short-range.md) tasks 1.2 and 1.3
+
+## Objective
+
+Replace the internal TCP-to-UDS proxy (SP21a) with native driver UDS support once scylla-rust-driver implements [#1616](https://github.com/scylladb/scylla-rust-driver/issues/1616). This eliminates the proxy overhead and complexity while keeping the same user-facing behavior.
+
+---
+
+## Prerequisites
+
+The scylla-rust-driver must implement (per issue #1616, milestone 1.7.0):
+
+1. `KnownNode::UnixSocket(PathBuf)` variant
+2. Transport abstraction supporting both TCP and Unix streams
+3. Disabled topology refresh for UDS connections
+4. `SessionBuilder::known_node_unix(path)` API
+
+---
+
+## What Changes from SP21a
+
+| SP21a Component | Action | Reason |
+|----------------|--------|--------|
+| `src/driver/uds_proxy.rs` | **Delete entirely** | No longer needed — driver connects directly |
+| `ScyllaDriver` proxy `JoinHandle` storage | **Remove** | No proxy to manage |
+| `is_unix_socket()` detection (Task 1.1) | **Keep** | Still need to detect UDS vs hostname |
+| `ConnectionConfig.unix_socket` (Task 1.4) | **Keep** | Still need to track UDS mode |
+| LOGIN reconnection (Task 2.1) | **Keep** | Still need to preserve UDS mode |
+| Platform guards (Task 3.1) | **Simplify** | Driver handles platform support |
+
+---
+
+## Implementation Tasks
+
+| # | Task | Description | Validation |
+|---|------|-------------|------------|
+| 1 | Upgrade scylla-rust-driver | Bump to version with UDS support (≥1.7.0 expected). Update `Cargo.toml`. | `cargo build` succeeds with new driver version |
+| 2 | Replace proxy with direct UDS connection | In `ScyllaDriver::connect()`, when `is_unix_socket()` is true, use `SessionBuilder::known_node_unix(path)` instead of starting the proxy. | Connection to UDS works without proxy |
+| 3 | Remove proxy infrastructure | Delete `src/driver/uds_proxy.rs`. Remove `JoinHandle` from `ScyllaDriver`. Remove proxy-related tests. | `cargo build` succeeds, no dead code warnings |
+| 4 | Disable topology refresh for UDS | Configure the driver to skip node discovery when connected via UDS (driver may handle this automatically — verify). | No spurious connection attempts to discovered TCP nodes |
+| 5 | Update tests | Replace proxy-based tests with direct UDS connection tests. Keep detection tests unchanged. | `cargo test` passes |
+| 6 | Update documentation | Note in README that native UDS is now supported via the driver. Remove proxy architecture notes. | Docs are accurate |
+
+---
+
+## Risks
+
+| ID | Risk | Mitigation |
+|----|------|-----------|
+| RISK-01 | Driver UDS API differs from expected | Adapt our integration code to match actual API. Detection and config plumbing remain stable. |
+| RISK-02 | Driver version with UDS has breaking changes | Review changelog, update other driver usage as needed. |
+| RISK-03 | Driver's UDS support is incomplete (e.g., no topology disable) | Keep manual topology disable logic from SP21a if needed. |
+
+---
+
+## Timeline
+
+- **Blocked on**: scylla-rust-driver #1616 (milestone 1.7.0)
+- **Effort once unblocked**: ~1-2 days (mostly deletion and simplification)
+- **SP21a remains functional** until this plan is executed — no urgency


### PR DESCRIPTION
## Summary

Port of [scylladb/scylla-cqlsh#67](https://github.com/scylladb/scylla-cqlsh/pull/67) — "Make cqlsh work with unix domain sockets" — as an implementation plan for cqlsh-rs.

## Problem

Python cqlsh gained Unix domain socket support for ScyllaDB's maintenance socket. cqlsh-rs needs the same capability, but the scylla-rust-driver has **no native UDS support** (hardcoded to TCP).

## Approach

**Built-in TCP-to-UDS proxy** on an ephemeral localhost port:

1. **Auto-detect**: When hostname is a Unix socket path (stat + S_ISSOCK), activate UDS mode
2. **Proxy**: Spawn a Tokio task binding 127.0.0.1:0, forwarding bidirectionally to UnixStream
3. **Transparent**: Driver connects to 127.0.0.1:ephemeral as normal TCP — zero driver changes
4. **Cleanup**: Proxy task stored in ScyllaDriver, aborted on drop

### Why not other approaches?

| Approach | Rejected because |
|----------|-----------------|
| External socat proxy | Requires user to install/manage extra tooling |
| Fork scylla-rust-driver | Maintenance burden |
| Wait for upstream UDS | Blocks the feature indefinitely |
| --unix-socket explicit flag | Breaks compatibility with Python cqlsh behavior |

## Plan details

Full plan in docs/plans/21-unix-domain-socket-support.md

- **Phase 1**: UDS detection + proxy infrastructure (4 tasks)
- **Phase 2**: LOGIN reconnection + docs (2 tasks)
- **Phase 3**: Testing + platform guards (4 tasks)

## Open questions

1. Should we also add an explicit --unix-socket flag alongside auto-detection?
2. Should we file upstream issue on scylla-rust-driver for native UDS support?
3. How does auto-node-discovery interact with UDS mode?

Upstream ref: scylladb/scylladb#16489