### PR TITLE
chore: release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/scylladb/cqlsh-rs/compare/v0.5.1...v0.5.2) - 2026-04-23
+
+### Fixed
+
+- *(repl)* preserve keyspace context across LOGIN
+
+### Other
+
+- *(codecov)* add codecov.yml with sensible thresholds
+- *(pager,login)* fix BrokenPipe in pager test; fix login keyspace assertion
+- *(login)* add integration test for keyspace preservation after LOGIN
+
 ## [0.5.1](https://github.com/scylladb/cqlsh-rs/compare/v0.5.0...v0.5.1) - 2026-04-22
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.5.1 -> 0.5.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.2](https://github.com/scylladb/cqlsh-rs/compare/v0.5.1...v0.5.2) - 2026-04-23

### Fixed

- *(repl)* preserve keyspace context across LOGIN

### Other

- *(codecov)* add codecov.yml with sensible thresholds
- *(pager,login)* fix BrokenPipe in pager test; fix login keyspace assertion
- *(login)* add integration test for keyspace preservation after LOGIN
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).