### PR TITLE
chore: release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/scylladb/cqlsh-rs/compare/v0.5.2...v0.5.3) - 2026-04-23
+
+### Other
+
+- *(describe)* convert last subprocess call to in-process for coverage
+- *(codecov)* wait for all 5 coverage uploads before posting status
+- *(integration)* call library code in-process for coverage-visible tests
+- *(executor)* extract CQL execution engine into injectable executor module
+
 ## [0.5.2](https://github.com/scylladb/cqlsh-rs/compare/v0.5.1...v0.5.2) - 2026-04-23
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.5.2 -> 0.5.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.3](https://github.com/scylladb/cqlsh-rs/compare/v0.5.2...v0.5.3) - 2026-04-23

### Other

- *(describe)* convert last subprocess call to in-process for coverage
- *(codecov)* wait for all 5 coverage uploads before posting status
- *(integration)* call library code in-process for coverage-visible tests
- *(executor)* extract CQL execution engine into injectable executor module
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).