### PR TITLE
chore(deps): bump scylla rust driver to 1.6.0 + track separately in Renovate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ configparser = "3"
 anyhow = "1"
 thiserror = "2"
 dirs = "6"
-scylla = { version = "1", features = ["rustls-023", "chrono-04", "num-bigint-04", "bigdecimal-04"] }
+scylla = { version = "1.6", features = ["rustls-023", "chrono-04", "num-bigint-04", "bigdecimal-04"] }
 tokio = { version = "1", features = ["full"] }
 rustls = "0.23"
 rustls-pemfile = "2"

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,14 @@
   "packageRules": [
     {
       "matchManagers": ["cargo"],
+      "matchPackageNames": ["scylla"],
+      "groupName": "scylla rust driver",
+      "groupSlug": "scylla-driver",
+      "automerge": false
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["!/^scylla/"],
       "groupName": "rust dependencies",
       "groupSlug": "rust-deps",
       "matchUpdateTypes": ["minor", "patch"],
@@ -13,6 +21,7 @@
     },
     {
       "matchManagers": ["cargo"],
+      "matchPackageNames": ["!/^scylla/"],
       "matchUpdateTypes": ["major"],
       "automerge": false
     },


### PR DESCRIPTION
## Summary

Two commits:

1. **ci(renovate):** Give the `scylla` crate its own Renovate group (`scylla-driver`) so driver updates get a dedicated PR instead of being lumped into the general rust-deps batch. `automerge: false` so driver bumps always get a manual review.

2. **chore(deps):** Bump `scylla` from `1.5.0` → `1.6.0`.

### Notable in 1.6.0 ([release notes](https://github.com/scylladb/scylla-rust-driver/releases/tag/v1.6.0))

- "Client Routes Routing" — driver works with AWS PrivateLink-style deployments
- `durable_writes` field added to `Keyspace` struct
- Bug fix: `query_iter`/`execute_iter` now refresh metadata after DDL
- ⚠️ MSRV bumped to **1.88**

### Verification

```
cargo check   # passes clean with -Dwarnings
```