### PR TITLE
fix: preserve keyspace context after LOGIN in executor mode

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -400,8 +400,14 @@ pub fn execute_single_statement<'a>(
             let mut new_config = config.clone();
             new_config.username = Some(new_user);
             new_config.password = new_pass;
+            let prev_keyspace = session.current_keyspace().map(str::to_string);
             match crate::session::CqlSession::connect(&new_config).await {
-                Ok(new_session) => {
+                Ok(mut new_session) => {
+                    if let Some(ks) = prev_keyspace {
+                        if let Err(e) = new_session.use_keyspace(&ks).await {
+                            eprintln!("Warning: could not restore keyspace '{ks}': {e}");
+                        }
+                    }
                     *session = new_session;
                 }
                 Err(e) => {


### PR DESCRIPTION
## Summary

- LOGIN in non-interactive (`-e`) mode created a new session without restoring the previously active keyspace, causing subsequent queries to fail with "table not found" errors
- Mirrors the keyspace preservation logic already present in the REPL LOGIN handler (`src/repl.rs` lines 522-532)

Closes #141

## Test

Existing integration test `login_preserves_keyspace_context` covers this scenario (USE keyspace → LOGIN → query unqualified table).