### PR TITLE
chore: release v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4](https://github.com/scylladb/cqlsh-rs/compare/v0.5.3...v0.5.4) - 2026-04-23
+
+### Fixed
+
+- resolve DESCRIBE <name> across all schema object types
+- include WITH clause in DESCRIBE MATERIALIZED VIEW output
+- preserve keyspace context after LOGIN in executor mode
+
+### Other
+
+- *(deps)* bump scylla rust driver from 1.5.0 to 1.6.0
+- *(renovate)* track scylla rust driver separately from other rust deps
+- *(repl)* add unit tests for print_help and print_help_topic
+
 ## [0.5.3](https://github.com/scylladb/cqlsh-rs/compare/v0.5.2...v0.5.3) - 2026-04-23
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.5.3 -> 0.5.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.4](https://github.com/scylladb/cqlsh-rs/compare/v0.5.3...v0.5.4) - 2026-04-23

### Fixed

- resolve DESCRIBE <name> across all schema object types
- include WITH clause in DESCRIBE MATERIALIZED VIEW output
- preserve keyspace context after LOGIN in executor mode

### Other

- *(deps)* bump scylla rust driver from 1.5.0 to 1.6.0
- *(renovate)* track scylla rust driver separately from other rust deps
- *(repl)* add unit tests for print_help and print_help_topic
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).