### PR TITLE
fix: suppress connection banner in non-interactive mode (-e, -f, pipe)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,10 +79,10 @@ async fn main() -> Result<()> {
 
     let stdin_is_pipe = !io::stdin().is_terminal() && !config.tty;
 
-    // Python cqlsh always prints the banner with -e/-f, only suppresses it when
-    // reading from a pipe/redirect without an explicit command.
-    let suppress_banner = stdin_is_pipe && config.execute.is_none() && config.file.is_none();
-    if !suppress_banner {
+    // Python cqlsh suppresses the banner in all non-interactive modes:
+    // -e (execute), -f (file), or piped/redirected stdin.
+    let is_interactive = !stdin_is_pipe && config.execute.is_none() && config.file.is_none();
+    if is_interactive {
         print_banner(&session);
     }
 

--- a/tests/integration/core_tests.rs
+++ b/tests/integration/core_tests.rs
@@ -528,17 +528,16 @@ fn test_consistency_command() {
 fn test_connection_banner() {
     let scylla = get_scylla();
 
-    // Run any command and check stderr for the connection banner
+    // With -e flag, banner should be suppressed (non-interactive mode)
     let output = cqlsh_cmd(scylla)
         .args(["-e", "SELECT release_version FROM system.local"])
         .output()
         .expect("failed to execute cqlsh-rs");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    // The banner is printed to stdout before the query result
     assert!(
-        stdout.contains("Connected to") || stdout.contains("cqlsh"),
-        "Expected connection banner in output: {stdout}"
+        !stdout.contains("Connected to"),
+        "Banner should NOT appear in non-interactive mode: {stdout}"
     );
 }
 

--- a/tests/integration/output_tests.rs
+++ b/tests/integration/output_tests.rs
@@ -350,7 +350,7 @@ fn test_blob_output() {
 
 #[test]
 #[ignore = "requires Docker"]
-fn test_connection_banner_format() {
+fn test_connection_banner_suppressed_with_execute_flag() {
     let scylla = get_scylla();
 
     let output = cqlsh_cmd(scylla)
@@ -360,20 +360,13 @@ fn test_connection_banner_format() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // Banner: "Connected to <cluster> at <host>."
     assert!(
-        stdout.contains("Connected to"),
-        "Expected 'Connected to' in banner: {stdout}"
+        !stdout.contains("Connected to"),
+        "Banner should NOT appear with -e flag: {stdout}"
     );
-    // Version line: "[cqlsh <version> | ...]"
     assert!(
-        stdout.contains("[cqlsh"),
-        "Expected '[cqlsh' version line: {stdout}"
-    );
-    // Help hint
-    assert!(
-        stdout.contains("Use HELP for help."),
-        "Expected help hint: {stdout}"
+        !stdout.contains("[cqlsh"),
+        "Version line should NOT appear with -e flag: {stdout}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Suppress the "Connected to..." banner when cqlsh-rs is invoked with `-e`, `-f`, or piped stdin — matching Python cqlsh behavior
- Tools like `scylla-doctor` that parse tabular cqlsh output were breaking because the banner line was included

Closes #146