### PR TITLE
docs: add Makefile and distribution build guide for glibc compatibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,38 @@ scylladb organization. To set up or verify crate ownership:
 > (OIDC). A `CARGO_REGISTRY_TOKEN` secret is required. Track the upstream
 > feature request at <https://github.com/rust-lang/crates.io/issues/7091>.
 
+### Building for distribution (glibc compatibility)
+
+Release binaries for Linux are **statically linked via musl**. This eliminates
+glibc version requirements entirely and ensures compatibility with:
+
+- RHEL 9 / Rocky Linux 9 / UBI9 (glibc 2.34)
+- Ubuntu 22.04+ (glibc 2.35)
+- ScyllaDB Docker images (ubi9-minimal)
+- Any Linux distribution regardless of glibc version
+
+**If you're packaging cqlsh-rs for a distribution or embedding it in a Docker
+image, always use the musl target:**
+
+```bash
+# x86_64 static binary
+make release-linux-x86_64
+# Binary at: target/x86_64-unknown-linux-musl/release/cqlsh-rs
+
+# aarch64 static binary (requires cross-rs)
+make release-linux-aarch64
+# Binary at: target/aarch64-unknown-linux-musl/release/cqlsh-rs
+```
+
+Or use pre-built binaries from
+[GitHub Releases](https://github.com/scylladb/cqlsh-rs/releases/latest) which
+are already statically linked.
+
+> **⚠️ Do not use `cargo build --release` on modern toolchains (Fedora 43+,
+> glibc 2.39) for distribution.** The resulting binary will require the build
+> host's glibc version and fail on older systems. Always use the musl target
+> or download pre-built static binaries.
+
 ### Docker images
 
 Multi-architecture Docker images (`linux/amd64` and `linux/arm64`) are

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,60 @@
+# cqlsh-rs build targets for distribution
+#
+# Release binaries for Linux are statically linked via musl to avoid glibc
+# version requirements. This ensures compatibility with RHEL 9+ (glibc 2.34),
+# Ubuntu 22.04+, and container images like ubi9-minimal.
+#
+# Usage:
+#   make release-linux-x86_64    # static x86_64 binary
+#   make release-linux-aarch64   # static aarch64 binary (requires cross)
+#   make release-linux           # both architectures
+
+CARGO ?= cargo
+CROSS ?= cross
+BINARY_NAME := cqlsh-rs
+
+# Default target
+.PHONY: build
+build:
+	$(CARGO) build --release
+
+# --- Static Linux builds (musl) ---
+
+.PHONY: release-linux-x86_64
+release-linux-x86_64:
+	rustup target add x86_64-unknown-linux-musl
+	$(CARGO) build --release --target x86_64-unknown-linux-musl
+	@echo ""
+	@echo "Binary: target/x86_64-unknown-linux-musl/release/$(BINARY_NAME)"
+	@echo "  Statically linked — no glibc dependency, runs on any Linux x86_64"
+
+.PHONY: release-linux-aarch64
+release-linux-aarch64:
+	$(CROSS) build --release --target aarch64-unknown-linux-musl
+	@echo ""
+	@echo "Binary: target/aarch64-unknown-linux-musl/release/$(BINARY_NAME)"
+	@echo "  Statically linked — no glibc dependency, runs on any Linux aarch64"
+
+.PHONY: release-linux
+release-linux: release-linux-x86_64 release-linux-aarch64
+
+# --- Development helpers ---
+
+.PHONY: test
+test:
+	$(CARGO) test
+
+.PHONY: clippy
+clippy:
+	$(CARGO) clippy --all-targets --all-features
+
+.PHONY: fmt
+fmt:
+	$(CARGO) fmt --all
+
+.PHONY: check
+check: fmt clippy test
+
+.PHONY: clean
+clean:
+	$(CARGO) clean


### PR DESCRIPTION
## Summary

- Adds a `Makefile` with `release-linux-x86_64` / `release-linux-aarch64` targets that produce statically-linked musl binaries (zero glibc dependency)
- Documents in CONTRIBUTING.md that external consumers must use musl targets or pre-built binaries — not plain `cargo build` on modern toolchains

Closes #147