### PR TITLE
chore: release v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6](https://github.com/scylladb/cqlsh-rs/compare/v0.5.5...v0.5.6) - 2026-05-04
+
+### Fixed
+
+- suppress connection banner in non-interactive mode (-e, -f, pipe)
+
 ## [0.5.5](https://github.com/scylladb/cqlsh-rs/compare/v0.5.4...v0.5.5) - 2026-05-04
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.5.5 -> 0.5.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.6](https://github.com/scylladb/cqlsh-rs/compare/v0.5.5...v0.5.6) - 2026-05-04

### Fixed

- suppress connection banner in non-interactive mode (-e, -f, pipe)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).