### PR TITLE
chore: release v0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.7](https://github.com/scylladb/cqlsh-rs/compare/v0.5.6...v0.5.7) - 2026-05-05
+
+### Fixed
+
+- treat underscore as word character in COPY keyword boundary detection
+- handle COPY TO/FROM in non-interactive mode (-e/-f flags)
+
+### Other
+
+- implementation plan for Unix domain socket support (SP21)
+- strengthen copy_dispatched probe to require exit code 0
+
 ## [0.5.6](https://github.com/scylladb/cqlsh-rs/compare/v0.5.5...v0.5.6) - 2026-05-04
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.5.6 -> 0.5.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.7](https://github.com/scylladb/cqlsh-rs/compare/v0.5.6...v0.5.7) - 2026-05-05

### Fixed

- treat underscore as word character in COPY keyword boundary detection
- handle COPY TO/FROM in non-interactive mode (-e/-f flags)

### Other

- implementation plan for Unix domain socket support (SP21)
- strengthen copy_dispatched probe to require exit code 0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).