### PR TITLE
fix: support // line comments in CQL parser (Python cqlsh compat)

### DIFF
--- a/src/cql_lexer.rs
+++ b/src/cql_lexer.rs
@@ -1086,6 +1086,15 @@ pub fn strip_comments(input: &str) -> String {
             continue;
         }
 
+        // Line comment: // to end of line (Python cqlsh compatibility)
+        if ch == b'/' && i + 1 < len && bytes[i + 1] == b'/' {
+            i += 2;
+            while i < len && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+
         // Block comment: /* ... */ (nested)
         if ch == b'/' && i + 1 < len && bytes[i + 1] == b'*' {
             let mut depth: usize = 1;
@@ -2034,6 +2043,18 @@ mod tests {
     fn strip_nested_block_comments() {
         let result = strip_comments("SELECT /* outer /* inner */ still */ 1");
         assert_eq!(result, "SELECT   1");
+    }
+
+    #[test]
+    fn strip_slash_slash_comment() {
+        let result = strip_comments("SELECT 1 // comment");
+        assert_eq!(result, "SELECT 1 ");
+    }
+
+    #[test]
+    fn strip_slash_slash_preserves_strings() {
+        let result = strip_comments("SELECT '// not a comment'");
+        assert_eq!(result, "SELECT '// not a comment'");
     }
 
     // ===== is_cql_keyword =====

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -165,7 +165,9 @@ impl StatementParser {
                     } else if ch == '$' && i + 1 < len && self.buffer.as_bytes()[i + 1] == b'$' {
                         self.state = LexState::DollarQuote;
                         i += 2;
-                    } else if ch == '-' && i + 1 < len && self.buffer.as_bytes()[i + 1] == b'-' {
+                    } else if (ch == '-' && i + 1 < len && self.buffer.as_bytes()[i + 1] == b'-')
+                        || (ch == '/' && i + 1 < len && self.buffer.as_bytes()[i + 1] == b'/')
+                    {
                         self.state = LexState::LineComment;
                         i += 2;
                     } else if ch == '/' && i + 1 < len && self.buffer.as_bytes()[i + 1] == b'*' {
@@ -1142,5 +1144,116 @@ mod tests {
         assert_eq!(stmts.len(), 1);
         assert!(stmts[0].starts_with("BEGIN BATCH"));
         assert!(stmts[0].ends_with("APPLY BATCH"));
+    }
+
+    #[test]
+    fn slash_slash_line_comment_stripped() {
+        let mut p = StatementParser::new();
+        let result = p.feed_line("SELECT 1; // post-line comment");
+        assert_eq!(result, ParseResult::Complete(vec!["SELECT 1".to_string()]));
+    }
+
+    #[test]
+    fn slash_slash_comment_mid_file() {
+        let mut p = StatementParser::new();
+        assert_eq!(p.feed_line("// this is a comment"), ParseResult::Incomplete);
+        let result = p.feed_line("SELECT 1;");
+        assert_eq!(result, ParseResult::Complete(vec!["SELECT 1".to_string()]));
+    }
+
+    #[test]
+    fn slash_slash_inside_string_not_treated_as_comment() {
+        let mut p = StatementParser::new();
+        let result = p.feed_line("SELECT '// not a comment';");
+        assert_eq!(
+            result,
+            ParseResult::Complete(vec!["SELECT '// not a comment'".to_string()])
+        );
+    }
+
+    #[test]
+    fn block_comment_chars_inside_string_literal() {
+        let mut p = StatementParser::new();
+        let result = p.feed_line("INSERT INTO t (v) VALUES ('test_role./*');");
+        assert_eq!(
+            result,
+            ParseResult::Complete(vec!["INSERT INTO t (v) VALUES ('test_role./*')".to_string()])
+        );
+    }
+
+    #[test]
+    fn block_comment_close_inside_string_literal() {
+        let mut p = StatementParser::new();
+        let result = p.feed_line("INSERT INTO t (v) VALUES ('v1*/');");
+        assert_eq!(
+            result,
+            ParseResult::Complete(vec!["INSERT INTO t (v) VALUES ('v1*/')".to_string()])
+        );
+    }
+
+    #[test]
+    fn mixed_comment_chars_in_strings() {
+        let mut p = StatementParser::new();
+        let result = p.feed_line("INSERT INTO t (a,b,c) VALUES ('aKey','v1*/','/v2/*/v3');");
+        assert_eq!(
+            result,
+            ParseResult::Complete(vec![
+                "INSERT INTO t (a,b,c) VALUES ('aKey','v1*/','/v2/*/v3')".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn double_dash_inside_string_not_comment() {
+        let mut p = StatementParser::new();
+        let result = p.feed_line("SELECT '-- not a comment';");
+        assert_eq!(
+            result,
+            ParseResult::Complete(vec!["SELECT '-- not a comment'".to_string()])
+        );
+    }
+
+    #[test]
+    fn inline_block_comment_stripped() {
+        let mut p = StatementParser::new();
+        let result = p.feed_line("SELECT /* inline */ * FROM t;");
+        assert_eq!(
+            result,
+            ParseResult::Complete(vec!["SELECT   * FROM t".to_string()])
+        );
+    }
+
+    #[test]
+    fn multiline_block_comment_across_feeds() {
+        let mut p = StatementParser::new();
+        assert_eq!(
+            p.feed_line("SELECT * FROM t WHERE"),
+            ParseResult::Incomplete
+        );
+        assert_eq!(p.feed_line("/* multi-line"), ParseResult::Incomplete);
+        assert_eq!(p.feed_line("   comment */"), ParseResult::Incomplete);
+        let result = p.feed_line("id = 1;");
+        assert_eq!(
+            result,
+            ParseResult::Complete(vec!["SELECT * FROM t WHERE\n \nid = 1".to_string()])
+        );
+    }
+
+    #[test]
+    fn comment_before_statement() {
+        let mut p = StatementParser::new();
+        assert_eq!(p.feed_line("/* comment */"), ParseResult::Incomplete);
+        let result = p.feed_line("SELECT 1;");
+        assert_eq!(result, ParseResult::Complete(vec!["SELECT 1".to_string()]));
+    }
+
+    #[test]
+    fn multiple_statements_with_comments() {
+        let mut p = StatementParser::new();
+        let result = p.feed_line("SELECT 1; -- comment\nSELECT 2;");
+        assert_eq!(
+            result,
+            ParseResult::Complete(vec!["SELECT 1".to_string(), "SELECT 2".to_string()])
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add `//` as a line comment delimiter in both the statement parser and comment stripper
- Python cqlsh accepts `//` comments, and ScyllaDB dtests use them (e.g. `DESCRIBE SCHEMA; // post-line comment`)
- Without this fix, text after `//` was sent to the server causing syntax errors like `no viable alternative at input 'globaloff'`

Closes #156