### PR TITLE
fix: use Python cqlsh-compatible tracing toggle messages

### DIFF
--- a/docs/book/src/commands/tracing.md
+++ b/docs/book/src/commands/tracing.md
@@ -14,7 +14,7 @@ TRACING
 
 ```
 cqlsh> TRACING ON
-Now tracing requests.
+Tracing is enabled
 
 cqlsh> SELECT * FROM system.local;
 -- query results --
@@ -22,7 +22,7 @@ cqlsh> SELECT * FROM system.local;
 Tracing session: 12345678-1234-1234-1234-123456789abc
 
 cqlsh> TRACING OFF
-Disabled tracing.
+Tracing is disabled
 ```
 
 ## Notes

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -255,12 +255,12 @@ pub fn execute_single_statement<'a>(
         }
         if upper == "TRACING OFF" || upper == "TRACING" {
             session.set_tracing(false);
-            let _ = writeln!(writer, "Disabled tracing.");
+            let _ = writeln!(writer, "Tracing is disabled");
             return true;
         }
         if upper == "TRACING ON" {
             session.set_tracing(true);
-            let _ = writeln!(writer, "Now tracing requests.");
+            let _ = writeln!(writer, "Tracing is enabled");
             return true;
         }
         if upper == "SHOW VERSION" {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -351,12 +351,12 @@ fn dispatch_input<'a>(
         // Handle TRACING
         if upper == "TRACING" || upper == "TRACING OFF" {
             session.set_tracing(false);
-            shell.outputln("Disabled tracing.");
+            shell.outputln("Tracing is disabled");
             return;
         }
         if upper == "TRACING ON" {
             session.set_tracing(true);
-            shell.outputln("Now tracing requests.");
+            shell.outputln("Tracing is enabled");
             return;
         }
 

--- a/tests/integration/dtest_cqlsh_tests.rs
+++ b/tests/integration/dtest_cqlsh_tests.rs
@@ -351,8 +351,52 @@ fn test_tracing() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
+        stdout.contains("Tracing is enabled"),
+        "Expected 'Tracing is enabled' confirmation in output: {stdout}"
+    );
+    assert!(
         stdout.contains("Tracing session:"),
         "Expected tracing session info in output: {stdout}"
+    );
+}
+
+#[test]
+#[ignore = "requires Docker"]
+fn test_tracing_off_message() {
+    let scylla = get_scylla();
+
+    let output = cqlsh_cmd(scylla)
+        .args(["-e", "TRACING OFF"])
+        .output()
+        .expect("failed to execute cqlsh-rs");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success());
+    assert!(
+        stdout.contains("Tracing is disabled"),
+        "Expected 'Tracing is disabled' confirmation in output: {stdout}"
+    );
+}
+
+#[test]
+#[ignore = "requires Docker"]
+fn test_tracing_toggle_messages() {
+    let scylla = get_scylla();
+
+    let output = cqlsh_cmd(scylla)
+        .args(["-e", "TRACING ON; TRACING OFF"])
+        .output()
+        .expect("failed to execute cqlsh-rs");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success());
+    assert!(
+        stdout.contains("Tracing is enabled"),
+        "Expected 'Tracing is enabled' in output: {stdout}"
+    );
+    assert!(
+        stdout.contains("Tracing is disabled"),
+        "Expected 'Tracing is disabled' in output: {stdout}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Changes `TRACING ON` output from "Now tracing requests." to "Tracing is enabled"
- Changes `TRACING OFF` output from "Disabled tracing." to "Tracing is disabled"
- Matches legacy Python cqlsh behavior that dtests rely on

## Testing

- Added `test_tracing_off_message` — verifies TRACING OFF confirmation
- Added `test_tracing_toggle_messages` — verifies both messages in sequence
- Updated existing `test_tracing` to also assert "Tracing is enabled" message

Fixes #157