### PR TITLE
chore: release v0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.9](https://github.com/scylladb/cqlsh-rs/compare/v0.5.8...v0.5.9) - 2026-05-05
+
+### Fixed
+
+- support // line comments in CQL parser (Python cqlsh compat)
+
 ## [0.5.8](https://github.com/scylladb/cqlsh-rs/compare/v0.5.7...v0.5.8) - 2026-05-05
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.5.8 -> 0.5.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.9](https://github.com/scylladb/cqlsh-rs/compare/v0.5.8...v0.5.9) - 2026-05-05

### Fixed

- support // line comments in CQL parser (Python cqlsh compat)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).