### PR TITLE
chore: release v0.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.10](https://github.com/scylladb/cqlsh-rs/compare/v0.5.9...v0.5.10) - 2026-05-07
+
+### Fixed
+
+- install ring CryptoProvider and implement TLS NoVerifier
+
+### Other
+
+- add auth integration tests and SSL+Auth CI job
+- rename SCYLLA_TEST_* env vars to CQLSH_TEST_*
+- add Cargo features to categorize integration tests
+
 ## [0.5.9](https://github.com/scylladb/cqlsh-rs/compare/v0.5.8...v0.5.9) - 2026-05-05
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.5.9 -> 0.5.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.10](https://github.com/scylladb/cqlsh-rs/compare/v0.5.9...v0.5.10) - 2026-05-07

### Fixed

- install ring CryptoProvider and implement TLS NoVerifier

### Other

- add auth integration tests and SSL+Auth CI job
- rename SCYLLA_TEST_* env vars to CQLSH_TEST_*
- add Cargo features to categorize integration tests
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).