### PR TITLE
chore: release v0.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.11](https://github.com/scylladb/cqlsh-rs/compare/v0.5.10...v0.5.11) - 2026-05-09
+
+### Added
+
+- auto-detect proxy and translate peer addresses to contact point
+
+### Fixed
+
+- *(driver)* address PR review feedback for proxy translator
+
 ## [0.5.10](https://github.com/scylladb/cqlsh-rs/compare/v0.5.9...v0.5.10) - 2026-05-07
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.5.10 -> 0.5.11 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.11](https://github.com/scylladb/cqlsh-rs/compare/v0.5.10...v0.5.11) - 2026-05-09

### Added

- auto-detect proxy and translate peer addresses to contact point

### Fixed

- *(driver)* address PR review feedback for proxy translator
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).