### PR TITLE
chore: release v0.5.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.12](https://github.com/scylladb/cqlsh-rs/compare/v0.5.11...v0.5.12) - 2026-06-11
+
+### Other
+
+- pin GitHub Actions to commit SHAs
+
 ## [0.5.11](https://github.com/scylladb/cqlsh-rs/compare/v0.5.10...v0.5.11) - 2026-05-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqlsh-rs"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 description = "A Rust re-implementation of the Apache Cassandra cqlsh shell"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `cqlsh-rs`: 0.5.11 -> 0.5.12 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.12](https://github.com/scylladb/cqlsh-rs/compare/v0.5.11...v0.5.12) - 2026-06-11

### Other

- pin GitHub Actions to commit SHAs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).